### PR TITLE
Update npm package name to @fresh-data/framework

### DIFF
--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "fresh-data": "file:../../",
     "react": "^16.4.0",
     "react-dom": "^16.4.0",
     "react-redux": "^5.0.7",

--- a/examples/hello-world/src/App.js
+++ b/examples/hello-world/src/App.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
-import { FreshDataProvider } from 'fresh-data';
+import { FreshDataProvider } from '@fresh-data/framework';
 import './App.css';
 import Message from './Message';
 import TestApi from './test-api';

--- a/examples/hello-world/src/Message.js
+++ b/examples/hello-world/src/Message.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { SECOND, withApiClient } from 'fresh-data';
+import { SECOND, withApiClient } from '@fresh-data/framework';
 
 class Message extends React.Component {
 	state = { counter: 0 };

--- a/examples/hello-world/src/reducer.js
+++ b/examples/hello-world/src/reducer.js
@@ -1,5 +1,5 @@
 import { combineReducers } from 'redux';
-import { reducer as freshData } from 'fresh-data';
+import { reducer as freshData } from '@fresh-data/framework';
 
 const reducers = {
 	freshData,

--- a/examples/hello-world/src/test-api.js
+++ b/examples/hello-world/src/test-api.js
@@ -1,4 +1,4 @@
-import { FreshDataApi } from 'fresh-data';
+import { FreshDataApi } from '@fresh-data/framework';
 
 const greetings = [
 	'Hello world!',

--- a/examples/wp-rest-api/package.json
+++ b/examples/wp-rest-api/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "dependencies": {
     "debug": "^3.1.0",
-    "fresh-data": "file:../../",
     "html-to-react": "^1.3.3",
     "qs": "^6.5.2",
     "react": "^16.4.0",

--- a/examples/wp-rest-api/src/App.js
+++ b/examples/wp-rest-api/src/App.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
-import { FreshDataProvider } from 'fresh-data';
+import { FreshDataProvider } from '@fresh-data/framework';
 import PostList from './PostList';
 import SiteSelect from './SiteSelect';
 import WpRestApi from './test-wp-rest-api';

--- a/examples/wp-rest-api/src/PostList.js
+++ b/examples/wp-rest-api/src/PostList.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { MINUTE, SECOND, withApiClient } from 'fresh-data';
+import { MINUTE, SECOND, withApiClient } from '@fresh-data/framework';
 import HtmlToReact from 'html-to-react';
 
 function renderPostLine( post ) {

--- a/examples/wp-rest-api/src/reducer.js
+++ b/examples/wp-rest-api/src/reducer.js
@@ -1,5 +1,5 @@
 import { combineReducers } from 'redux';
-import { reducer as freshData } from 'fresh-data';
+import { reducer as freshData } from '@fresh-data/framework';
 
 const reducers = {
 	freshData,

--- a/examples/wp-rest-api/src/test-wp-rest-api.js
+++ b/examples/wp-rest-api/src/test-wp-rest-api.js
@@ -1,5 +1,5 @@
 import { startsWith } from 'lodash';
-import { FreshDataApi } from 'fresh-data';
+import { FreshDataApi } from '@fresh-data/framework';
 import qs from 'qs';
 
 const NAMESPACE = 'wp/v2';

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-	"name": "fresh-data",
+	"name": "@fresh-data/framework",
 	"version": "0.1.0",
 	"description": "Describe the data you need and simply use it in your app.",
 	"license": "GPL-2.0+",
-	"homepage": "https://github.com/coderkevin/fresh-data#readme",
-	"repository": "github:coderkevin/fresh-data",
-	"bugs": "https://github.com/coderkevin/fresh-data/issues",
+	"homepage": "https://github.com/automattic/fresh-data#readme",
+	"repository": "github:automattic/fresh-data",
+	"bugs": "https://github.com/automattic/fresh-data/issues",
 	"keywords": [
 		"javascript",
 		"api",
@@ -35,7 +35,6 @@
 		"build:umd": "cross-env BABEL_ENV=rollup NODE_ENV=development rollup -c -o dist/fresh-data.js",
 		"build:umd:min": "cross-env BABEL_ENV=rollup NODE_ENV=production rollup -c -o dist/fresh-data.min.js",
 		"build": "npm run build:commonjs && npm run build:es && npm run build:umd && npm run build:umd:min",
-		"postinstall": "npm run clean && npm run build",
 		"prepublishOnly": "npm run clean && npm run lint && npm test && npm run build"
 	},
 	"peerDependencies": {


### PR DESCRIPTION
This updates the npm package name to @fresh-data/framework.
It also temporarily removes the dependency in the example code, but will
be added back after this change is in master.

To Test:
1. `npm install`, `npm run build`, `npm link`.
2. cd into `examples/hello-world` and `npm install`, `npm link @fresh-data/framework`, `npm start`.
3. cd into `examples/wp-rest-api` and `npm install`, `npm link @fresh-data/framework`, `npm start`.
