### PR TITLE
examples: Update to use 0.1.0 release

### DIFF
--- a/examples/hello-world/package-lock.json
+++ b/examples/hello-world/package-lock.json
@@ -5,10 +5,23 @@
   "requires": true,
   "dependencies": {
     "@fresh-data/framework": {
-      "version": "github:automattic/fresh-data#452066bc165e24443741121a4f3f23a53105b8ea",
-      "from": "github:automattic/fresh-data",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@fresh-data/framework/-/framework-0.1.0.tgz",
+      "integrity": "sha512-ZqCGYiqSuQDbRk0qNE1TmyiLh+dLKGmwxfPd4g+u/jpwDZCPFkjdwtx5/hC/ewdxy4W1+YdyqC5gZGb8Sf2OhA==",
       "requires": {
-        "prop-types": "^15.6.1"
+        "postinstall-build": "^5.0.1",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "prop-types": {
+          "version": "15.6.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+          "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        }
       }
     },
     "abab": {
@@ -9025,6 +9038,11 @@
           }
         }
       }
+    },
+    "postinstall-build": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/postinstall-build/-/postinstall-build-5.0.1.tgz",
+      "integrity": "sha1-uRepB5smF42aJK9aXNjLSpkdEbk="
     },
     "prelude-ls": {
       "version": "1.1.2",

--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@fresh-data/framework": "github:automattic/fresh-data",
+    "@fresh-data/framework": "^0.1.0",
     "ajv": "^6.5.2",
     "debug": "^3.1.0",
     "lodash": "^4.17.10",

--- a/examples/wp-rest-api/package-lock.json
+++ b/examples/wp-rest-api/package-lock.json
@@ -5,10 +5,23 @@
   "requires": true,
   "dependencies": {
     "@fresh-data/framework": {
-      "version": "github:automattic/fresh-data#452066bc165e24443741121a4f3f23a53105b8ea",
-      "from": "github:automattic/fresh-data",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@fresh-data/framework/-/framework-0.1.0.tgz",
+      "integrity": "sha512-ZqCGYiqSuQDbRk0qNE1TmyiLh+dLKGmwxfPd4g+u/jpwDZCPFkjdwtx5/hC/ewdxy4W1+YdyqC5gZGb8Sf2OhA==",
       "requires": {
-        "prop-types": "^15.6.1"
+        "postinstall-build": "^5.0.1",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "prop-types": {
+          "version": "15.6.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+          "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        }
       }
     },
     "abab": {
@@ -8716,6 +8729,11 @@
           }
         }
       }
+    },
+    "postinstall-build": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/postinstall-build/-/postinstall-build-5.0.1.tgz",
+      "integrity": "sha1-uRepB5smF42aJK9aXNjLSpkdEbk="
     },
     "prelude-ls": {
       "version": "1.1.2",

--- a/examples/wp-rest-api/package.json
+++ b/examples/wp-rest-api/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@fresh-data/framework": "github:automattic/fresh-data",
+    "@fresh-data/framework": "^0.1.0",
     "ajv": "^6.5.2",
     "debug": "^3.1.0",
     "html-to-react": "^1.3.3",


### PR DESCRIPTION
This updates the example apps to use the npm released code. No more `npm link` or `github:` required.