### PR TITLE
Change getData/requireData to getResource/requireResource

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,10 +120,9 @@ export default class MyApi extends FreshDataApi {
 	}
 
 	static selectors = {
-		getThing: ( getResource, requireData ) => ( requirement, thingId ) => {
+		getThing: ( getResource, requireResource ) => ( requirement, thingId ) => {
 			const resourceName = `thing:${ thingId }`;
-			requireData( requirement, resourceName );
-			return getResource( resourceName ).data || {};
+			return requireResource( requirement, resourceName );
 		}
 	}
 }

--- a/README.md
+++ b/README.md
@@ -120,10 +120,10 @@ export default class MyApi extends FreshDataApi {
 	}
 
 	static selectors = {
-		getThing: ( getData, requireData ) => ( requirement, thingId ) => {
+		getThing: ( getResource, requireData ) => ( requirement, thingId ) => {
 			const resourceName = `thing:${ thingId }`;
 			requireData( requirement, resourceName );
-			return getData( resourceName ) || {};
+			return getResource( resourceName ).data || {};
 		}
 	}
 }

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -75,19 +75,19 @@ export default class ApiClient {
 		return resource;
 	};
 
+	requireResource = ( componentRequirements ) => ( requirement, resourceName ) => {
+		componentRequirements.push( { ...requirement, resourceName } );
+		return this.getResource( resourceName );
+	};
+
 	getMutations = () => {
 		return this.mutations;
 	}
 
-	requireData = ( componentRequirements ) => ( requirement, resourceName ) => {
-		componentRequirements.push( { ...requirement, resourceName } );
-		return componentRequirements;
-	};
-
 	setComponentData = ( component, selectorFunc, now = new Date() ) => {
 		if ( selectorFunc ) {
 			const componentRequirements = [];
-			const selectors = mapFunctions( this.api.selectors, this.getResource, this.requireData( componentRequirements ) );
+			const selectors = mapFunctions( this.api.selectors, this.getResource, this.requireResource( componentRequirements ) );
 			selectorFunc( selectors );
 
 			this.requirementsByComponent.set( component, componentRequirements );

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -69,10 +69,10 @@ export default class ApiClient {
 		return callback;
 	}
 
-	getData = ( resourceName ) => {
+	getResource = ( resourceName ) => {
 		const resources = this.state.resources || {};
 		const resource = resources[ resourceName ] || {};
-		return resource.data;
+		return resource;
 	};
 
 	getMutations = () => {
@@ -87,7 +87,7 @@ export default class ApiClient {
 	setComponentData = ( component, selectorFunc, now = new Date() ) => {
 		if ( selectorFunc ) {
 			const componentRequirements = [];
-			const selectors = mapFunctions( this.api.selectors, this.getData, this.requireData( componentRequirements ) );
+			const selectors = mapFunctions( this.api.selectors, this.getResource, this.requireData( componentRequirements ) );
 			selectorFunc( selectors );
 
 			this.requirementsByComponent.set( component, componentRequirements );


### PR DESCRIPTION
Addresses #65 

This changes `getData` to `getResource`, to return the entire resource state. This allows selectors access to metadata like `lastReceived`, `lastRequested`, `lastError`, and `error`.

It also changes `requireData` to `requireResource` to match, and `requireResource` also returns the resource state, just like `getResource` to save a line of code in selectors.

This PR also adds some more tests around these two functions for added coverage.

To Test:
1. `npm install`, `npm test` and ensure all tests pass.