### PR TITLE
Move static api members to instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,65 +70,61 @@ Modules for each API can be kept in your application or a separate module.
 import { compact, startsWith } from 'lodash';
 
 export default class MyApi extends FreshDataApi {
-	constructor() {
-		const methods = {
-			get: ( clientKey ) => ( endpointPath, params ) => {
-				const uri = clientKey + endpointPath.join( '/' );
-				const queryString = qs.stringify( params );
-				return fetch( `${ uri }?${ query }` );
-			},
-			put: ( clientKey ) => ( endpointPath, params ) => {
-				const uri = clientKey + endpointPath.join( '/' );
-				const { data } = params;
-				return fetch( uri, { method: 'PUT', body: JSON.stringify( data ) } );
-			}
+	methods = {
+		get: ( clientKey ) => ( endpointPath, params ) => {
+			const uri = clientKey + endpointPath.join( '/' );
+			const queryString = qs.stringify( params );
+			return fetch( `${ uri }?${ query }` );
+		},
+		put: ( clientKey ) => ( endpointPath, params ) => {
+			const uri = clientKey + endpointPath.join( '/' );
+			const { data } = params;
+			return fetch( uri, { method: 'PUT', body: JSON.stringify( data ) } );
 		}
+	}
 
-		const operations = {
-			read: ( methods ) => ( resourceNames ) => {
-				return compact( resourceNames.map( resourceName => {
-					if ( startsWith( resourceName, 'thing:' ) ) {
-						const thingNumber = resourceName.substr( resourceName.indexOf( ':' ) + 1 );
+	operations = {
+		read: ( methods ) => ( resourceNames ) => {
+			return compact( resourceNames.map( resourceName => {
+				if ( startsWith( resourceName, 'thing:' ) ) {
+					const thingNumber = resourceName.substr( resourceName.indexOf( ':' ) + 1 );
 
-						const request = methods.get( [ 'things' ] ).then( responseData => {
-							return { [ resourceName ]: { data: responseData } };
-						} );
-						return request;
-					}
-				} ) );
-			}
-			update: ( methods ) => ( resourceNames, resourceData ) => {
-				return compact( resourceNames.map( resourceName => {
-					if ( startsWith( resourceName, 'thing:' ) ) {
-						const thingNumber = resourceName.substr( resourceName.indexOf( ':' ) + 1 );
-						const data = resourceData[ resourceName ];
-
-						const request = methods.put( [ 'things' ], { data } ).then( responseData => {
-							return { [ resourceName ]: { data: responseData } };
-						} );
-						return request;
-					}
-				} ) );
-			}
+					const request = methods.get( [ 'things' ] ).then( responseData => {
+						return { [ resourceName ]: { data: responseData } };
+					} );
+					return request;
+				}
+			} ) );
 		}
+		update: ( methods ) => ( resourceNames, resourceData ) => {
+			return compact( resourceNames.map( resourceName => {
+				if ( startsWith( resourceName, 'thing:' ) ) {
+					const thingNumber = resourceName.substr( resourceName.indexOf( ':' ) + 1 );
+					const data = resourceData[ resourceName ];
 
-		const mutations = {
-			updateThing: ( operations ) => ( thingId, data ) => {
-				const resourceName = `thing:${ thingId }`;
-				const resourceNames = [ resourceName ];
-				const resourceData = { [ resourceName ]: data };
-				return operations.update( resourceNames, resourceData );
-			}
+					const request = methods.put( [ 'things' ], { data } ).then( responseData => {
+						return { [ resourceName ]: { data: responseData } };
+					} );
+					return request;
+				}
+			} ) );
 		}
+	}
 
-		const selectors = {
-			getThing: ( getResource, requireResource ) => ( requirement, thingId ) => {
-				const resourceName = `thing:${ thingId }`;
-				return requireResource( requirement, resourceName );
-			}
+	mutations = {
+		updateThing: ( operations ) => ( thingId, data ) => {
+			const resourceName = `thing:${ thingId }`;
+			const resourceNames = [ resourceName ];
+			const resourceData = { [ resourceName ]: data };
+			return operations.update( resourceNames, resourceData );
 		}
+	}
 
-		super( methods, operations, mutations, selectors );
+	selectors = {
+		getThing: ( getResource, requireResource ) => ( requirement, thingId ) => {
+			const resourceName = `thing:${ thingId }`;
+			return requireResource( requirement, resourceName );
+		}
 	}
 }
 ```

--- a/src/api/__tests__/index.spec.js
+++ b/src/api/__tests__/index.spec.js
@@ -21,7 +21,9 @@ describe( 'api', () => {
 		it( 'should use api methods defined in subclass', () => {
 			const methods = { get: () => {} };
 			class MyApi extends FreshDataApi {
-				static methods = methods;
+				constructor() {
+					super( methods, {}, {}, {} );
+				}
 			}
 			const api = new MyApi();
 			expect( api.methods ).toBe( methods );
@@ -30,28 +32,34 @@ describe( 'api', () => {
 		it( 'should use operations defined in subclass', () => {
 			const operations = { read: () => {} };
 			class MyApi extends FreshDataApi {
-				static operations = operations;
+				constructor() {
+					super( {}, operations, {}, {} );
+				}
 			}
 			const api = new MyApi();
 			expect( api.operations ).toBe( operations );
 		} );
 
-		it( 'should use selector methods defined in subclass', () => {
-			const selectors = { getThings: () => () => {} };
-			class MyApi extends FreshDataApi {
-				static selectors = selectors;
-			}
-			const api = new MyApi();
-			expect( api.selectors ).toBe( selectors );
-		} );
-
 		it( 'should use mutation methods defined in subclass', () => {
 			const mutations = { getThings: () => () => {} };
 			class MyApi extends FreshDataApi {
-				static mutations = mutations;
+				constructor() {
+					super( {}, {}, mutations, {} );
+				}
 			}
 			const api = new MyApi();
 			expect( api.mutations ).toBe( mutations );
+		} );
+
+		it( 'should use selector methods defined in subclass', () => {
+			const selectors = { getThings: () => () => {} };
+			class MyApi extends FreshDataApi {
+				constructor() {
+					super( {}, {}, {}, selectors );
+				}
+			}
+			const api = new MyApi();
+			expect( api.selectors ).toBe( selectors );
 		} );
 	} );
 

--- a/src/api/__tests__/index.spec.js
+++ b/src/api/__tests__/index.spec.js
@@ -17,50 +17,6 @@ describe( 'api', () => {
 			const api = new FreshDataApi();
 			expect( api.dataHandler ).toEqual( null );
 		} );
-
-		it( 'should use api methods defined in subclass', () => {
-			const methods = { get: () => {} };
-			class MyApi extends FreshDataApi {
-				constructor() {
-					super( methods, {}, {}, {} );
-				}
-			}
-			const api = new MyApi();
-			expect( api.methods ).toBe( methods );
-		} );
-
-		it( 'should use operations defined in subclass', () => {
-			const operations = { read: () => {} };
-			class MyApi extends FreshDataApi {
-				constructor() {
-					super( {}, operations, {}, {} );
-				}
-			}
-			const api = new MyApi();
-			expect( api.operations ).toBe( operations );
-		} );
-
-		it( 'should use mutation methods defined in subclass', () => {
-			const mutations = { getThings: () => () => {} };
-			class MyApi extends FreshDataApi {
-				constructor() {
-					super( {}, {}, mutations, {} );
-				}
-			}
-			const api = new MyApi();
-			expect( api.mutations ).toBe( mutations );
-		} );
-
-		it( 'should use selector methods defined in subclass', () => {
-			const selectors = { getThings: () => () => {} };
-			class MyApi extends FreshDataApi {
-				constructor() {
-					super( {}, {}, {}, selectors );
-				}
-			}
-			const api = new MyApi();
-			expect( api.selectors ).toBe( selectors );
-		} );
 	} );
 
 	describe( '#setDataHandler', () => {

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -4,24 +4,16 @@ import ApiClient from '../client/index';
 const debug = debugFactory( 'fresh-data:api' );
 
 export default class FreshDataApi {
-	// TODO: Consider making these part of the instance instead of the class.
-	// It would allow the use of `this` to retrieve things like methods and resources.
-	static methods = {}
-	static operations = {}
-	static selectors = {}
-	static mutations = {}
-
-	constructor() {
+	constructor( methods = {}, operations = {}, mutations = {}, selectors = {} ) {
+		// TODO: Validate things coming in from the constructo?
+		this.methods = methods;
+		this.operations = operations;
+		this.mutations = mutations;
+		this.selectors = selectors;
 		this.clients = new Map();
 		this.state = {};
 		this.dataHandler = null;
 		this.readOperationName = 'read';
-
-		// TODO: Validate methods, resources, selectors here.
-		this.methods = this.constructor.methods;
-		this.operations = this.constructor.operations;
-		this.selectors = this.constructor.selectors;
-		this.mutations = this.constructor.mutations;
 	}
 
 	setDataHandler = ( dataHandler ) => {

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -4,12 +4,13 @@ import ApiClient from '../client/index';
 const debug = debugFactory( 'fresh-data:api' );
 
 export default class FreshDataApi {
-	constructor( methods = {}, operations = {}, mutations = {}, selectors = {} ) {
-		// TODO: Validate things coming in from the constructo?
-		this.methods = methods;
-		this.operations = operations;
-		this.mutations = mutations;
-		this.selectors = selectors;
+	methods = {};
+	operations = {};
+	mutations = {};
+	selectors = {};
+
+	constructor() {
+		// TODO: Validate methods, operations, mutations, and selectors?
 		this.clients = new Map();
 		this.state = {};
 		this.dataHandler = null;

--- a/src/client/__tests__/index.spec.js
+++ b/src/client/__tests__/index.spec.js
@@ -72,20 +72,13 @@ describe( 'ApiClient', () => {
 	it( 'should map api methods to client key', () => {
 		const checkMethod = jest.fn();
 		class TestApi extends FreshDataApi {
-			constructor() {
-				super(
-					{ // methods
-						get: ( clientKey ) => ( endpointPath ) => ( params ) => {
-							checkMethod( 'get', clientKey, endpointPath, params );
-						},
-						post: ( clientKey ) => ( endpointPath ) => ( params ) => {
-							checkMethod( 'post', clientKey, endpointPath, params );
-						},
-					},
-					{}, // operations
-					{}, // mutations
-					{} // selectors
-				);
+			methods = {
+				get: ( clientKey ) => ( endpointPath ) => ( params ) => {
+					checkMethod( 'get', clientKey, endpointPath, params );
+				},
+				post: ( clientKey ) => ( endpointPath ) => ( params ) => {
+					checkMethod( 'post', clientKey, endpointPath, params );
+				},
 			}
 		}
 		const api = new TestApi();
@@ -104,18 +97,14 @@ describe( 'ApiClient', () => {
 	it( 'should map operations to methods', () => {
 		const checkOperation = jest.fn();
 		class TestApi extends FreshDataApi {
-			constructor() {
-				super(
-					{ get: () => () => {} }, // methods
-					{ // operations
-						read: ( methods ) => ( resourceNames, data ) => {
-							checkOperation( methods, resourceNames, data );
-							return [];
-						},
-					},
-					{}, // mutations
-					{} // selectors
-				);
+			methods = {
+				get: () => () => {},
+			}
+			operations = {
+				read: ( methods ) => ( resourceNames, data ) => {
+					checkOperation( methods, resourceNames, data );
+					return [];
+				},
 			}
 		}
 		const api = new TestApi();
@@ -131,15 +120,8 @@ describe( 'ApiClient', () => {
 		createThing.mockReturnValue( mappedCreateThing );
 
 		class TestApi extends FreshDataApi {
-			constructor() {
-				super(
-					{}, // methods
-					{}, // operations
-					{ // mutations
-						createThing,
-					},
-					{}, // selectors
-				);
+			mutations = {
+				createThing,
 			}
 		}
 
@@ -153,14 +135,7 @@ describe( 'ApiClient', () => {
 
 	it( 'should map getResource to current state', () => {
 		class TestApi extends FreshDataApi {
-			constructor() {
-				super(
-					{}, // methods
-					{}, // operations
-					{}, // mutations
-					thingSelectors, // selectors
-				);
-			}
+			selectors = thingSelectors;
 		}
 		const api = new TestApi();
 		const apiClient = new ApiClient( api, '123' );
@@ -240,14 +215,7 @@ describe( 'ApiClient', () => {
 
 	describe( '#setComponentData', () => {
 		class TestApi extends FreshDataApi {
-			constructor() {
-				super(
-					{}, // methods
-					{}, // operations
-					{}, // mutations
-					thingSelectors,
-				);
-			}
+			selectors = thingSelectors;
 		}
 		const api = new TestApi();
 
@@ -341,14 +309,7 @@ describe( 'ApiClient', () => {
 
 		it( 'should calculate nextUpdate when not given.', () => {
 			class TestApi extends FreshDataApi {
-				constructor() {
-					super(
-						{}, // methods
-						{}, // operations
-						{}, // mutations
-						thingSelectors, // selectors
-					);
-				}
+				selectors = thingSelectors;
 			}
 			const api = new TestApi();
 			const setTimer = jest.fn();
@@ -387,14 +348,7 @@ describe( 'ApiClient', () => {
 
 	describe( '#updateRequirementsData', () => {
 		class TestApi extends FreshDataApi {
-			constructor() {
-				super(
-					{}, // methods
-					{}, // operations
-					{}, // mutations
-					thingSelectors, // selectors
-				);
-			}
+			selectors = thingSelectors;
 		}
 		const api = new TestApi();
 		const component = () => {};
@@ -520,26 +474,19 @@ describe( 'ApiClient', () => {
 
 		beforeEach( () => {
 			class TestApi extends FreshDataApi {
-				constructor() {
-					super(
-						{}, // methods
-						{ // operations
-							read: () => () => {
-								const returnObject = {
-									'type:1': { data: { attribute: 'some' } },
-								};
-								const returnPromise = new Promise( ( resolve ) => {
-									resolve( {
-										'thing:2': { data: { color: 'blue' } },
-										'thing:3': { data: { color: 'green' } },
-									} );
-								} );
-								return [ returnObject, returnPromise ];
-							},
-						},
-						{}, // mutations
-						{}, // selectors
-					);
+				operations = {
+					read: () => () => {
+						const returnObject = {
+							'type:1': { data: { attribute: 'some' } },
+						};
+						const returnPromise = new Promise( ( resolve ) => {
+							resolve( {
+								'thing:2': { data: { color: 'blue' } },
+								'thing:3': { data: { color: 'green' } },
+							} );
+						} );
+						return [ returnObject, returnPromise ];
+					},
 				}
 			}
 			api = new TestApi();
@@ -549,18 +496,11 @@ describe( 'ApiClient', () => {
 		it( 'should call the corresponding api operation handlers.', () => {
 			const readFunc = jest.fn();
 			class TestApi extends FreshDataApi {
-				constructor() {
-					super(
-						{}, // methods
-						{ // operations
-							read: ( methods ) => ( resourceNames, data ) => {
-								readFunc( methods, resourceNames, data );
-								return [];
-							},
-						},
-						{}, // mutations
-						{}, // selectors
-					);
+				operations = {
+					read: ( methods ) => ( resourceNames, data ) => {
+						readFunc( methods, resourceNames, data );
+						return [];
+					},
 				}
 			}
 			api = new TestApi();
@@ -572,14 +512,6 @@ describe( 'ApiClient', () => {
 
 		it( 'should throw error if no read function is found.', () => {
 			class TestApi extends FreshDataApi {
-				constructor() {
-					super(
-						{}, // methods
-						{}, // operations
-						{}, // mutations
-						{}, // selectors
-					);
-				}
 			}
 			api = new TestApi();
 			apiClient = new ApiClient( api, '123' );
@@ -589,17 +521,10 @@ describe( 'ApiClient', () => {
 
 		it( 'should not crash if the operation returns undefined', () => {
 			class TestApi extends FreshDataApi {
-				constructor() {
-					super(
-						{}, // methods
-						{ // operations
-							read: () => () => {
-								return undefined;
-							}
-						},
-						{}, // mutations
-						{}, // selectors
-					);
+				operations = {
+					read: () => () => {
+						return undefined;
+					},
 				}
 			}
 			api = new TestApi();
@@ -642,17 +567,10 @@ describe( 'ApiClient', () => {
 
 		it( 'should handle an error thrown from within an operation function.', () => {
 			class TestApi extends FreshDataApi {
-				constructor() {
-					super(
-						{}, // methods
-						{ // operations
-							read: () => () => {
-								throw new Error( 'BOOM!' );
-							},
-						},
-						{}, // mutations
-						{}, // selectors
-					);
+				operations = {
+					read: () => () => {
+						throw new Error( 'BOOM!' );
+					},
 				}
 			}
 			api = new TestApi();
@@ -668,19 +586,12 @@ describe( 'ApiClient', () => {
 
 		it( 'should handle an unhandled error from within a promise.', () => {
 			class TestApi extends FreshDataApi {
-				constructor() {
-					super(
-						{}, // methods
-						{ // operations
-							read: () => () => {
-								return new Promise( () => {
-									throw new Error( 'BOOM!' );
-								} );
-							},
-						},
-						{}, // mutations
-						{}, // selectors
-					);
+				operations = {
+					read: () => () => {
+						return new Promise( () => {
+							throw new Error( 'BOOM!' );
+						} );
+					},
 				}
 			}
 			api = new TestApi();

--- a/src/client/__tests__/index.spec.js
+++ b/src/client/__tests__/index.spec.js
@@ -72,14 +72,21 @@ describe( 'ApiClient', () => {
 	it( 'should map api methods to client key', () => {
 		const checkMethod = jest.fn();
 		class TestApi extends FreshDataApi {
-			static methods = {
-				get: ( clientKey ) => ( endpointPath ) => ( params ) => {
-					checkMethod( 'get', clientKey, endpointPath, params );
-				},
-				post: ( clientKey ) => ( endpointPath ) => ( params ) => {
-					checkMethod( 'post', clientKey, endpointPath, params );
-				},
-			};
+			constructor() {
+				super(
+					{ // methods
+						get: ( clientKey ) => ( endpointPath ) => ( params ) => {
+							checkMethod( 'get', clientKey, endpointPath, params );
+						},
+						post: ( clientKey ) => ( endpointPath ) => ( params ) => {
+							checkMethod( 'post', clientKey, endpointPath, params );
+						},
+					},
+					{}, // operations
+					{}, // mutations
+					{} // selectors
+				);
+			}
 		}
 		const api = new TestApi();
 		const apiClient = new ApiClient( api, '123' );
@@ -97,12 +104,18 @@ describe( 'ApiClient', () => {
 	it( 'should map operations to methods', () => {
 		const checkOperation = jest.fn();
 		class TestApi extends FreshDataApi {
-			static methods = { get: () => () => {} };
-			static operations = {
-				read: ( methods ) => ( resourceNames, data ) => {
-					checkOperation( methods, resourceNames, data );
-					return [];
-				},
+			constructor() {
+				super(
+					{ get: () => () => {} }, // methods
+					{ // operations
+						read: ( methods ) => ( resourceNames, data ) => {
+							checkOperation( methods, resourceNames, data );
+							return [];
+						},
+					},
+					{}, // mutations
+					{} // selectors
+				);
 			}
 		}
 		const api = new TestApi();
@@ -118,8 +131,15 @@ describe( 'ApiClient', () => {
 		createThing.mockReturnValue( mappedCreateThing );
 
 		class TestApi extends FreshDataApi {
-			static mutations = {
-				createThing,
+			constructor() {
+				super(
+					{}, // methods
+					{}, // operations
+					{ // mutations
+						createThing,
+					},
+					{}, // selectors
+				);
 			}
 		}
 
@@ -133,7 +153,14 @@ describe( 'ApiClient', () => {
 
 	it( 'should map getResource to current state', () => {
 		class TestApi extends FreshDataApi {
-			static selectors = thingSelectors;
+			constructor() {
+				super(
+					{}, // methods
+					{}, // operations
+					{}, // mutations
+					thingSelectors, // selectors
+				);
+			}
 		}
 		const api = new TestApi();
 		const apiClient = new ApiClient( api, '123' );
@@ -213,7 +240,14 @@ describe( 'ApiClient', () => {
 
 	describe( '#setComponentData', () => {
 		class TestApi extends FreshDataApi {
-			static selectors = thingSelectors;
+			constructor() {
+				super(
+					{}, // methods
+					{}, // operations
+					{}, // mutations
+					thingSelectors,
+				);
+			}
 		}
 		const api = new TestApi();
 
@@ -307,7 +341,14 @@ describe( 'ApiClient', () => {
 
 		it( 'should calculate nextUpdate when not given.', () => {
 			class TestApi extends FreshDataApi {
-				static selectors = thingSelectors;
+				constructor() {
+					super(
+						{}, // methods
+						{}, // operations
+						{}, // mutations
+						thingSelectors, // selectors
+					);
+				}
 			}
 			const api = new TestApi();
 			const setTimer = jest.fn();
@@ -346,12 +387,14 @@ describe( 'ApiClient', () => {
 
 	describe( '#updateRequirementsData', () => {
 		class TestApi extends FreshDataApi {
-			static resources = {
-				read: [
-					() => () => {},
-				],
-			};
-			static selectors = thingSelectors;
+			constructor() {
+				super(
+					{}, // methods
+					{}, // operations
+					{}, // mutations
+					thingSelectors, // selectors
+				);
+			}
 		}
 		const api = new TestApi();
 		const component = () => {};
@@ -477,19 +520,26 @@ describe( 'ApiClient', () => {
 
 		beforeEach( () => {
 			class TestApi extends FreshDataApi {
-				static operations = {
-					read: () => () => {
-						const returnObject = {
-							'type:1': { data: { attribute: 'some' } },
-						};
-						const returnPromise = new Promise( ( resolve ) => {
-							resolve( {
-								'thing:2': { data: { color: 'blue' } },
-								'thing:3': { data: { color: 'green' } },
-							} );
-						} );
-						return [ returnObject, returnPromise ];
-					},
+				constructor() {
+					super(
+						{}, // methods
+						{ // operations
+							read: () => () => {
+								const returnObject = {
+									'type:1': { data: { attribute: 'some' } },
+								};
+								const returnPromise = new Promise( ( resolve ) => {
+									resolve( {
+										'thing:2': { data: { color: 'blue' } },
+										'thing:3': { data: { color: 'green' } },
+									} );
+								} );
+								return [ returnObject, returnPromise ];
+							},
+						},
+						{}, // mutations
+						{}, // selectors
+					);
 				}
 			}
 			api = new TestApi();
@@ -499,11 +549,18 @@ describe( 'ApiClient', () => {
 		it( 'should call the corresponding api operation handlers.', () => {
 			const readFunc = jest.fn();
 			class TestApi extends FreshDataApi {
-				static operations = {
-					read: ( methods ) => ( resourceNames, data ) => {
-						readFunc( methods, resourceNames, data );
-						return [];
-					},
+				constructor() {
+					super(
+						{}, // methods
+						{ // operations
+							read: ( methods ) => ( resourceNames, data ) => {
+								readFunc( methods, resourceNames, data );
+								return [];
+							},
+						},
+						{}, // mutations
+						{}, // selectors
+					);
 				}
 			}
 			api = new TestApi();
@@ -515,7 +572,14 @@ describe( 'ApiClient', () => {
 
 		it( 'should throw error if no read function is found.', () => {
 			class TestApi extends FreshDataApi {
-				static operations = {};
+				constructor() {
+					super(
+						{}, // methods
+						{}, // operations
+						{}, // mutations
+						{}, // selectors
+					);
+				}
 			}
 			api = new TestApi();
 			apiClient = new ApiClient( api, '123' );
@@ -525,11 +589,18 @@ describe( 'ApiClient', () => {
 
 		it( 'should not crash if the operation returns undefined', () => {
 			class TestApi extends FreshDataApi {
-				static operations = {
-					read: () => () => {
-						return undefined;
-					}
-				};
+				constructor() {
+					super(
+						{}, // methods
+						{ // operations
+							read: () => () => {
+								return undefined;
+							}
+						},
+						{}, // mutations
+						{}, // selectors
+					);
+				}
 			}
 			api = new TestApi();
 			apiClient = new ApiClient( api, '123' );
@@ -571,10 +642,17 @@ describe( 'ApiClient', () => {
 
 		it( 'should handle an error thrown from within an operation function.', () => {
 			class TestApi extends FreshDataApi {
-				static operations = {
-					read: () => () => {
-						throw new Error( 'BOOM!' );
-					},
+				constructor() {
+					super(
+						{}, // methods
+						{ // operations
+							read: () => () => {
+								throw new Error( 'BOOM!' );
+							},
+						},
+						{}, // mutations
+						{}, // selectors
+					);
 				}
 			}
 			api = new TestApi();
@@ -590,12 +668,19 @@ describe( 'ApiClient', () => {
 
 		it( 'should handle an unhandled error from within a promise.', () => {
 			class TestApi extends FreshDataApi {
-				static operations = {
-					read: () => () => {
-						return new Promise( () => {
-							throw new Error( 'BOOM!' );
-						} );
-					},
+				constructor() {
+					super(
+						{}, // methods
+						{ // operations
+							read: () => () => {
+								return new Promise( () => {
+									throw new Error( 'BOOM!' );
+								} );
+							},
+						},
+						{}, // mutations
+						{}, // selectors
+					);
 				}
 			}
 			api = new TestApi();

--- a/src/react-redux/__tests__/with-api-client.spec.js
+++ b/src/react-redux/__tests__/with-api-client.spec.js
@@ -6,17 +6,10 @@ import withApiClient from '../with-api-client';
 
 describe( 'withApiClient', () => {
 	class TestApi extends FreshDataApi {
-		constructor() {
-			super(
-				{}, // methods
-				{}, // operations
-				{}, // mutations
-				{ // selectors
-					getThing: () => () => {
-						return { id: 1, color: 'red' };
-					},
-				}
-			);
+		selectors = {
+			getThing: () => () => {
+				return { id: 1, color: 'red' };
+			},
 		}
 	}
 
@@ -273,33 +266,28 @@ describe( 'withApiClient', () => {
 			const updateFunc = jest.fn();
 
 			class MutationsTestApi extends FreshDataApi {
-				constructor() {
-					super(
-						{ // methods
-							put: ( clientKey ) => ( path, data ) => {
-								putFunc( clientKey, path, data );
-							}
-						},
-						{ // operations
-							update: ( { put } ) => ( resourceNames, resourceData ) => {
-								const filteredNames = resourceNames.filter( name => startsWith( name, 'thing:' ) );
-								return filteredNames.reduce( ( requests, name ) => {
-									const id = name.substr( name.indexOf( ':' ) + 1 );
-									const data = resourceData[ name ];
-									requests[ name ] = put( [ 'things', id ], { data } );
-									return requests;
-								}, {} );
-							},
-						},
-						{ // mutations
-							updateThing: ( operations ) => ( id, data ) => {
-								updateFunc( id, data );
-								const resourceName = `thing:${ id }`;
-								operations.update( [ resourceName ], { [ resourceName ]: data } );
-							}
-						},
-						{}
-					);
+				methods = {
+					put: ( clientKey ) => ( path, data ) => {
+						putFunc( clientKey, path, data );
+					},
+				}
+				operations = {
+					update: ( { put } ) => ( resourceNames, resourceData ) => {
+						const filteredNames = resourceNames.filter( name => startsWith( name, 'thing:' ) );
+						return filteredNames.reduce( ( requests, name ) => {
+							const id = name.substr( name.indexOf( ':' ) + 1 );
+							const data = resourceData[ name ];
+							requests[ name ] = put( [ 'things', id ], { data } );
+							return requests;
+						}, {} );
+					},
+				}
+				mutations = {
+					updateThing: ( operations ) => ( id, data ) => {
+						updateFunc( id, data );
+						const resourceName = `thing:${ id }`;
+						operations.update( [ resourceName ], { [ resourceName ]: data } );
+					},
 				}
 			}
 


### PR DESCRIPTION
Addresses #69 

This moves `methods`, `operations`, `mutations`, and `selectors` from
static class members to instance members passed via the base class
constructor.

It will allow the `this` context to be used for these functions, and it
will also allow different `methods` to be passed in for different
instances of apis, which will prove valuable when running in different
environments.

Note that most of the line changes are in the tests. These don't need to be scrutinized much as long as the tests still run successfully.

To Test:
1. `npm install`, `npm test` and ensure all tests pass.

Additional testing for this PR can be done by following the test instructions in #73 