### PR TITLE
Update examples to 0.2.0

### DIFF
--- a/examples/hello-world/src/test-api.js
+++ b/examples/hello-world/src/test-api.js
@@ -34,8 +34,8 @@ const greetings = [
 let requestCount = 0;
 
 export default class TestApi extends FreshDataApi {
-	static methods = {
-		get: ( clientKey ) => ( endpointPath ) => ( params ) => { // eslint-disable-line no-unused-vars
+	methods = {
+		get: ( clientKey ) => ( endpointPath, params ) => { // eslint-disable-line no-unused-vars
 			return new Promise( ( resolve ) => {
 				requestCount++;
 				const valueCount = Math.min( requestCount, greetings.length );
@@ -45,12 +45,12 @@ export default class TestApi extends FreshDataApi {
 		},
 	}
 
-	static operations = {
+	operations = {
 		read: ( { get } ) => ( resourceNames ) => {
 			const requests = [];
 			resourceNames.forEach( resourceName => {
 				if ( 'greetings' === resourceName ) {
-					const request = get( [ 'greetings' ] )()
+					const request = get( [ 'greetings' ] )
 						.then( data => {
 							const resources = { greetings: { data } };
 							return resources;
@@ -62,11 +62,10 @@ export default class TestApi extends FreshDataApi {
 		}
 	}
 
-	static selectors = {
-		getGreetings: ( getData, requireData ) => ( requirement ) => {
+	selectors = {
+		getGreetings: ( getResource, requireResource ) => ( requirement ) => {
 			const resourceName = 'greetings';
-			requireData( requirement, resourceName );
-			return getData( resourceName ) || [];
+			return requireResource( requirement, resourceName ).data || [];
 		}
 	}
 }

--- a/examples/wp-rest-api/src/test-wp-rest-api.js
+++ b/examples/wp-rest-api/src/test-wp-rest-api.js
@@ -7,8 +7,8 @@ const API_URL_PREFIX = `wp-json/${ NAMESPACE }`;
 
 export function createApi( fetch = window.fetch ) {
 	class TestWPRestApi extends FreshDataApi {
-		static methods = {
-			get: ( clientKey ) => ( endpointPath ) => ( params ) => { // eslint-disable-line no-unused-vars
+		methods = {
+			get: ( clientKey ) => ( endpointPath, params ) => { // eslint-disable-line no-unused-vars
 				const baseUrl = `${ clientKey }/${ API_URL_PREFIX }`;
 				const path = endpointPath.join( '/' );
 				const httpParams = { page: params.page, per_page: params.perPage }; // eslint-disable-line camelcase
@@ -25,18 +25,17 @@ export function createApi( fetch = window.fetch ) {
 			},
 		}
 
-		static operations = {
+		operations = {
 			read: ( { get } ) => ( resourceNames ) => {
 				return readPostPages( get, resourceNames );
 			},
 		}
 
-		static selectors = {
-			getPosts: ( getData, requireData ) => ( requirement, page = 1, perPage = 10 ) => {
+		selectors = {
+			getPosts: ( getResource, requireResource ) => ( requirement, page = 1, perPage = 10 ) => {
 				const resourceName = `posts-page:{"page":${ page },"perPage":${ perPage }}`;
-				requireData( requirement, resourceName );
-				const pageIds = getData( resourceName ) || [];
-				const pagePosts = pageIds.map( id => getData( `post:${ id }` ) ) || {};
+				const pageIds = requireResource( requirement, resourceName ).data || [];
+				const pagePosts = pageIds.map( id => getResource( `post:${ id }` ).data );
 				return pagePosts;
 			}
 		}
@@ -51,7 +50,7 @@ export function readPostPages( get, resourceNames ) {
 			const params = JSON.parse( resourceName.substr( resourceName.indexOf( ':' ) + 1 ) );
 
 			// Do a get for each page.
-			const request = get( [ 'posts' ] )( params )
+			const request = get( [ 'posts' ], params )
 			.then( responseData => {
 				// Store each post separately so it can be used by the rest of the app.
 				const postsById = responseData.reduce( ( posts, data ) => {


### PR DESCRIPTION
This updates the example code to the upcoming 0.2.0 release.

Required changes are:

1. `getData`/`requireData` -> `getResource`/`requireResource`
2. `methods`, `operations`, `mutations`, `selectors` no longer static

To Test:

0. `npm install`, `npm run build`, `npm link`
1. cd to `examples/hello-world`, `npm install`, `npm link @fresh-data/framework`, `npm start`
2. cd to `examples/wp-rest-api`, `npm install`, `npm link @fresh-data/framework`, `npm start`
