### PR TITLE
API and Client promise updates

### DIFF
--- a/examples/hello-world/src/test-api.js
+++ b/examples/hello-world/src/test-api.js
@@ -34,8 +34,8 @@ const greetings = [
 let requestCount = 0;
 
 export default class TestApi extends FreshDataApi {
-	static methods = {
-		get: ( clientKey ) => ( endpointPath ) => ( params ) => { // eslint-disable-line no-unused-vars
+	methods = {
+		get: ( clientKey ) => ( endpointPath, params ) => { // eslint-disable-line no-unused-vars
 			return new Promise( ( resolve ) => {
 				requestCount++;
 				const valueCount = Math.min( requestCount, greetings.length );
@@ -45,12 +45,12 @@ export default class TestApi extends FreshDataApi {
 		},
 	}
 
-	static operations = {
+	operations = {
 		read: ( { get } ) => ( resourceNames ) => {
 			const requests = [];
 			resourceNames.forEach( resourceName => {
 				if ( 'greetings' === resourceName ) {
-					const request = get( [ 'greetings' ] )()
+					const request = get( [ 'greetings' ] )
 						.then( data => {
 							const resources = { greetings: { data } };
 							return resources;
@@ -62,11 +62,10 @@ export default class TestApi extends FreshDataApi {
 		}
 	}
 
-	static selectors = {
-		getGreetings: ( getData, requireData ) => ( requirement ) => {
+	selectors = {
+		getGreetings: ( getResource, requireResource ) => ( requirement ) => {
 			const resourceName = 'greetings';
-			requireData( requirement, resourceName );
-			return getData( resourceName ) || [];
+			return requireResource( requirement, resourceName ).data || [];
 		}
 	}
 }

--- a/examples/wp-rest-api/src/PostList.js
+++ b/examples/wp-rest-api/src/PostList.js
@@ -16,10 +16,12 @@ function renderPostLine( post ) {
 	);
 }
 
-function PostList( { posts, siteUrl } ) {
+function PostList( { isLoading, posts, siteUrl } ) {
+	const heading = isLoading ? 'Loading' : 'Recent Posts for';
+
 	return (
 		<div className="post-list">
-			<h3>Recent Posts for</h3>
+			<h3>{ heading }</h3>
 			<h4><pre>{ siteUrl }</pre></h4>
 			<table>
 				<tbody>
@@ -36,9 +38,12 @@ PostList.propTypes = {
 };
 
 function mapSelectorsToProps( selectors ) {
-	const { getPosts } = selectors;
-	const posts = getPosts( { freshness: 5 * MINUTE, timeout: 3 * SECOND } );
+	const { getPostsPage, isPostsPageLoading } = selectors;
+	const params = { page: 1, perPage: 10 };
+	const posts = getPostsPage( { freshness: 5 * MINUTE, timeout: 3 * SECOND }, params );
+	const isLoading = isPostsPageLoading( params );
 	return {
+		isLoading,
 		posts,
 	};
 }

--- a/examples/wp-rest-api/src/test-wp-rest-api.js
+++ b/examples/wp-rest-api/src/test-wp-rest-api.js
@@ -7,8 +7,8 @@ const API_URL_PREFIX = `wp-json/${ NAMESPACE }`;
 
 export function createApi( fetch = window.fetch ) {
 	class TestWPRestApi extends FreshDataApi {
-		static methods = {
-			get: ( clientKey ) => ( endpointPath ) => ( params ) => { // eslint-disable-line no-unused-vars
+		methods = {
+			get: ( clientKey ) => ( endpointPath, params ) => { // eslint-disable-line no-unused-vars
 				const baseUrl = `${ clientKey }/${ API_URL_PREFIX }`;
 				const path = endpointPath.join( '/' );
 				const httpParams = { page: params.page, per_page: params.perPage }; // eslint-disable-line camelcase
@@ -25,18 +25,17 @@ export function createApi( fetch = window.fetch ) {
 			},
 		}
 
-		static operations = {
+		operations = {
 			read: ( { get } ) => ( resourceNames ) => {
 				return readPostPages( get, resourceNames );
 			},
 		}
 
-		static selectors = {
-			getPosts: ( getData, requireData ) => ( requirement, page = 1, perPage = 10 ) => {
+		selectors = {
+			getPosts: ( getResource, requireResource ) => ( requirement, page = 1, perPage = 10 ) => {
 				const resourceName = `posts-page:{"page":${ page },"perPage":${ perPage }}`;
-				requireData( requirement, resourceName );
-				const pageIds = getData( resourceName ) || [];
-				const pagePosts = pageIds.map( id => getData( `post:${ id }` ) ) || {};
+				const pageIds = requireResource( requirement, resourceName ).data || [];
+				const pagePosts = pageIds.map( id => getResource( `post:${ id }` ).data );
 				return pagePosts;
 			}
 		}
@@ -51,7 +50,7 @@ export function readPostPages( get, resourceNames ) {
 			const params = JSON.parse( resourceName.substr( resourceName.indexOf( ':' ) + 1 ) );
 
 			// Do a get for each page.
-			const request = get( [ 'posts' ] )( params )
+			const request = get( [ 'posts' ], params )
 			.then( responseData => {
 				// Store each post separately so it can be used by the rest of the app.
 				const postsById = responseData.reduce( ( posts, data ) => {

--- a/examples/wp-rest-api/src/test-wp-rest-api.js
+++ b/examples/wp-rest-api/src/test-wp-rest-api.js
@@ -32,11 +32,19 @@ export function createApi( fetch = window.fetch ) {
 		}
 
 		selectors = {
-			getPosts: ( getResource, requireResource ) => ( requirement, page = 1, perPage = 10 ) => {
-				const resourceName = `posts-page:{"page":${ page },"perPage":${ perPage }}`;
+			getPostsPage: ( getResource, requireResource ) => ( requirement, params ) => {
+				const paramsString = JSON.stringify( params, Object.keys( params ).sort() );
+				const resourceName = 'posts-page:' + paramsString;
 				const pageIds = requireResource( requirement, resourceName ).data || [];
 				const pagePosts = pageIds.map( id => getResource( `post:${ id }` ).data );
 				return pagePosts;
+			},
+
+			isPostsPageLoading: ( getResource ) => ( params ) => {
+				const paramsString = JSON.stringify( params, Object.keys( params ).sort() );
+				const resourceName = 'posts-page:' + paramsString;
+				const { data, lastRequested, lastReceived = 0 } = getResource( resourceName );
+				return ( ! data || ( lastRequested && lastRequested > lastReceived ) );
 			}
 		}
 	}

--- a/src/api/__tests__/index.spec.js
+++ b/src/api/__tests__/index.spec.js
@@ -211,6 +211,19 @@ describe( 'api', () => {
 			expect( dataRequested ).toHaveBeenCalledTimes( 1 );
 			expect( dataRequested ).toHaveBeenCalledWith( api, clientKey, [ 'thing:3', 'thing:4' ] );
 		} );
+
+		it( 'should return resourceNames given', () => {
+			const resourceNames = [ 'thing:3', 'thing:4' ];
+			const dataRequested = jest.fn();
+			dataRequested.mockReturnValue( resourceNames );
+
+			class MyApi extends FreshDataApi {
+			}
+			const api = new MyApi();
+			api.setDataHandlers( { dataRequested } );
+
+			expect( api.dataRequested( clientKey, resourceNames ) ).toBe( resourceNames );
+		} );
 	} );
 
 	describe( '#dataReceived', () => {
@@ -241,6 +254,21 @@ describe( 'api', () => {
 				'thing:3': { data: { color: 'grey' } },
 				'thing:4': { error: { message: 'oops' } },
 			} );
+		} );
+
+		it( 'should return resources', () => {
+			const dataRequested = jest.fn();
+			const dataReceived = jest.fn();
+			class MyApi extends FreshDataApi {
+			}
+			const api = new MyApi();
+			const resources = {
+				'thing:3': { data: { color: 'grey' } },
+				'thing:4': { error: { message: 'oops' } },
+			};
+
+			api.setDataHandlers( { dataRequested, dataReceived } );
+			expect( api.dataReceived( clientKey, resources ) ).toBe( resources );
 		} );
 	} );
 

--- a/src/api/__tests__/index.spec.js
+++ b/src/api/__tests__/index.spec.js
@@ -46,6 +46,24 @@ describe( 'api', () => {
 			expect( api.clients.size ).toBe( 1 );
 			expect( api.clients.get( 'myKey' ) ).toEqual( client );
 		} );
+
+		it( 'should not create a client if the key is null', () => {
+			class MyApi extends FreshDataApi {
+			}
+			const api = new MyApi();
+			const client = api.createClient( null );
+
+			expect( client ).toBeNull();
+		} );
+
+		it( 'should not create a client if the key is undefined', () => {
+			class MyApi extends FreshDataApi {
+			}
+			const api = new MyApi();
+			const client = api.createClient( undefined );
+
+			expect( client ).toBeNull();
+		} );
 	} );
 
 	describe( '#findClient', () => {

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -56,6 +56,7 @@ export default class FreshDataApi {
 	 * Sets requested data states for resources.
 	 * @param {string} clientKey The clientKey for the api instance.
 	 * @param {Array} resourceNames Array of resourceName.
+	 * @return {Array} The resourceNames given.
 	 */
 	dataRequested( clientKey, resourceNames ) {
 		if ( ! this.dataHandlers ) {
@@ -63,12 +64,14 @@ export default class FreshDataApi {
 			return;
 		}
 		this.dataHandlers.dataRequested( this, clientKey, resourceNames );
+		return resourceNames;
 	}
 
 	/**
 	 * Sets received data states for resources.
 	 * @param {string} clientKey The clientKey for the api instance.
 	 * @param {Object} resources Data keyed by resourceName.
+	 * @return {Object} The resources given.
 	 */
 	dataReceived( clientKey, resources ) {
 		if ( ! this.dataHandlers ) {
@@ -76,6 +79,7 @@ export default class FreshDataApi {
 			return;
 		}
 		this.dataHandlers.dataReceived( this, clientKey, resources );
+		return resources;
 	}
 
 	/**
@@ -84,6 +88,7 @@ export default class FreshDataApi {
 	 * @param {string} operationName The name of the operation attempted.
 	 * @param {Array} resourceNames The names of resources requested.
 	 * @param {any} error The error returned from the operation.
+	 * @return {any} The error received.
 	 */
 	unhandledErrorReceived( clientKey, operationName, resourceNames, error ) {
 		debug(
@@ -91,5 +96,6 @@ export default class FreshDataApi {
 			' resourceNames:', resourceNames,
 			' error:', error
 		);
+		return error;
 	}
 }

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -30,6 +30,10 @@ export default class FreshDataApi {
 	}
 
 	createClient( clientKey ) {
+		if ( ! clientKey ) {
+			return null;
+		}
+
 		const client = new ApiClient( this, clientKey );
 		this.clients.set( clientKey, client );
 		client.setState( this.state );

--- a/src/client/__tests__/index.spec.js
+++ b/src/client/__tests__/index.spec.js
@@ -552,13 +552,13 @@ describe( 'ApiClient', () => {
 			const resourceNames = [ 'thing:2', 'thing:3', 'type:1' ];
 			const dataReceived = jest.fn();
 
-			apiClient.dataReceived = dataReceived;
+			api.dataReceived = dataReceived;
 			apiClient.applyOperation( 'read', resourceNames ).then( () => {
 				expect( dataReceived ).toHaveBeenCalledTimes( 2 );
-				expect( dataReceived ).toHaveBeenCalledWith( {
+				expect( dataReceived ).toHaveBeenCalledWith( '123', {
 					'type:1': { data: { attribute: 'some' } },
 				} );
-				expect( dataReceived ).toHaveBeenCalledWith( {
+				expect( dataReceived ).toHaveBeenCalledWith( '123', {
 					'thing:2': { data: { color: 'blue' } },
 					'thing:3': { data: { color: 'green' } },
 				} );
@@ -577,10 +577,12 @@ describe( 'ApiClient', () => {
 			apiClient = new ApiClient( api, '123' );
 			const unhandled = jest.fn();
 
-			apiClient.unhandledErrorReceived = unhandled;
+			api.unhandledErrorReceived = unhandled;
 			apiClient.applyOperation( 'read', [ 'thing:1' ] ).then( () => {
+			} ).catch( ( error ) => {
 				expect( unhandled ).toHaveBeenCalledTimes( 1 );
-				expect( unhandled ).toHaveBeenCalledWith( 'read', [ 'thing:1' ], new Error( 'BOOM!' ) );
+				expect( unhandled ).toHaveBeenCalledWith( '123', 'read', [ 'thing:1' ], new Error( 'BOOM!' ) );
+				expect( error ).toEqual( new Error( 'BOOM!' ) );
 			} );
 		} );
 
@@ -600,8 +602,10 @@ describe( 'ApiClient', () => {
 
 			apiClient.unhandledErrorReceived = unhandled;
 			apiClient.applyOperation( 'read', [ 'thing:1' ] ).then( () => {
+			} ).catch( ( error ) => {
 				expect( unhandled ).toHaveBeenCalledTimes( 1 );
 				expect( unhandled ).toHaveBeenCalledWith( 'read', [ 'thing:1' ], new Error( 'BOOM!' ) );
+				expect( error ).toEqual( new Error( 'BOOM!' ) );
 			} );
 		} );
 	} );

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -35,7 +35,7 @@ export default class ApiClient {
 	mapOperations = ( apiOperations ) => {
 		return Object.keys( apiOperations ).reduce( ( operations, operationName ) => {
 			operations[ operationName ] = ( resourceNames, data ) => {
-				this.applyOperation( operationName, resourceNames, data );
+				return this.applyOperation( operationName, resourceNames, data );
 			};
 			return operations;
 		}, {} );
@@ -167,7 +167,7 @@ export default class ApiClient {
 			throw new Error( `Operation "${ operationName } not found.` );
 		}
 
-		const rootPromise = new Promise( () => {
+		const rootPromise = new Promise( ( resolve, reject ) => {
 			try {
 				const operationResult = apiOperation( this.methods )( resourceNames, data ) || [];
 				const values = isArray( operationResult ) ? operationResult : [ operationResult ];
@@ -182,9 +182,12 @@ export default class ApiClient {
 				} );
 
 				// TODO: Maybe some monitoring of promises to ensure they all resolve?
-				return Promise.all( requests );
+				const all = Promise.all( requests );
+				resolve( all );
+				//resolve( Promise.all( requests ) );
 			} catch ( error ) {
 				this.api.unhandledErrorReceived( this.key, operationName, resourceNames, error );
+				reject( error );
 			}
 		} );
 		return rootPromise;


### PR DESCRIPTION
This PR updates the behavior around applying operations and promises. The goal of it is to return promises from operations and therefore be able to use these promises to resolve success/fail behavior in mutations. This will allow notifications and resolving interim optimistic states.

To Test:
1. `npm install`
2. `npm test`

There will be more testing in the application use of this after it is merged.