### PR TITLE
Provider: Single api only.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,8 +10,8 @@ export { default as FreshDataApi } from './api/index';
 // Combine this in your top-level Redux reducer under 'freshData'.
 export { default as reducer } from './react-redux/reducer/index';
 
-// Add this component as a child of your Redux provider.
-export { default as FreshDataProvider } from './react-redux/provider';
+// Children of the ApiProvider can access API data from context.
+export { default as ApiProvider } from './react-redux/provider';
 
 // Use this within FreshDataProvider to wrap your component with api state.
 export { default as withApiClient } from './react-redux/with-api-client';

--- a/src/react-redux/__tests__/provider.spec.js
+++ b/src/react-redux/__tests__/provider.spec.js
@@ -3,29 +3,30 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ApiClient from '../../client';
 import FreshDataApi from '../../api';
-import { FreshDataReduxProvider, mapStateToProps } from '../provider';
+import { ApiProvider, mapStateToProps } from '../provider';
 import * as actions from '../actions';
 
-describe( 'FreshDataReduxProvider', () => {
+describe( 'ApiProvider', () => {
 	class TestApi extends FreshDataApi {
 	}
 
-	let apis;
+	let api;
 
 	beforeEach( () => {
-		apis = { test: new TestApi() };
+		api = new TestApi();
 	} );
 
 	it( 'should render without crashing.', () => {
 		mount(
-			<FreshDataReduxProvider
-				apis={ apis }
+			<ApiProvider
+				api={ api }
+				apiName={ 'test-api' }
 				rootData={ {} }
 				dataRequested={ actions.dataRequested }
 				dataReceived={ actions.dataReceived }
 			>
 				<span>Testing</span>
-			</FreshDataReduxProvider>
+			</ApiProvider>
 		);
 	} );
 
@@ -42,14 +43,15 @@ describe( 'FreshDataReduxProvider', () => {
 			ChildComponent.contextTypes = { getApiClient: PropTypes.func };
 
 			const wrapper = mount(
-				<FreshDataReduxProvider
-					apis={ apis }
+				<ApiProvider
+					api={ api }
+					apiName={ 'test-api' }
 					rootData={ {} }
 					dataRequested={ actions.dataRequested }
 					dataReceived={ actions.dataReceived }
 				>
 					<ChildComponent />
-				</FreshDataReduxProvider>
+				</ApiProvider>
 			);
 
 			expect( childContext ).toBeInstanceOf( Object );
@@ -58,102 +60,113 @@ describe( 'FreshDataReduxProvider', () => {
 
 		it( 'should return newly created api client.', () => {
 			const wrapper = mount(
-				<FreshDataReduxProvider
-					apis={ apis }
+				<ApiProvider
+					api={ api }
+					apiName={ 'test-api' }
 					rootData={ {} }
 					dataRequested={ actions.dataRequested }
 					dataReceived={ actions.dataReceived }
 				>
 					<span>Testing</span>
-				</FreshDataReduxProvider>
+				</ApiProvider>
 			);
-			expect( wrapper.instance().getApiClient( 'test', '123' ) ).toBeInstanceOf( ApiClient );
+			expect( wrapper.instance().getApiClient( '123' ) ).toBeInstanceOf( ApiClient );
 		} );
 
 		it( 'should return already created api client.', () => {
 			const wrapper = mount(
-				<FreshDataReduxProvider
-					apis={ apis }
+				<ApiProvider
+					api={ api }
+					apiName={ 'test-api' }
 					rootData={ {} }
 					dataRequested={ actions.dataRequested }
 					dataReceived={ actions.dataReceived }
 				>
 					<span>Testing</span>
-				</FreshDataReduxProvider>
+				</ApiProvider>
 			);
-			const apiClient = wrapper.instance().getApiClient( 'test', '123' );
-			expect( wrapper.instance().getApiClient( 'test', '123' ) ).toBe( apiClient );
+			const apiClient = wrapper.instance().getApiClient( '123' );
+			expect( wrapper.instance().getApiClient( '123' ) ).toBe( apiClient );
 		} );
 
-		it( 'should return null if incorrect api name is given.', () => {
+		it( 'should return undefined if no api prop is set.', () => {
+			class ApiProviderOptionalPropTypes extends ApiProvider {
+				static propTypes = {};
+			}
+
 			const wrapper = mount(
-				<FreshDataReduxProvider
-					apis={ apis }
+				<ApiProviderOptionalPropTypes
+					api={ null }
+					apiName={ 'test-api' }
 					rootData={ {} }
 					dataRequested={ actions.dataRequested }
 					dataReceived={ actions.dataReceived }
 				>
 					<span>Testing</span>
-				</FreshDataReduxProvider>
+				</ApiProviderOptionalPropTypes>
 			);
-			expect( wrapper.instance().getApiClient( 'tst', '123' ) ).toBeNull();
+			expect( wrapper.instance().getApiClient( '123' ) ).toBeUndefined();
 		} );
 	} );
 
 	describe( '#updateApis', () => {
 		it( 'should set api data handlers initially.', () => {
-			apis.test.setDataHandlers = jest.fn();
+			api.setDataHandlers = jest.fn();
 
 			mount(
-				<FreshDataReduxProvider
-					apis={ apis }
+				<ApiProvider
+					api={ api }
+					apiName={ 'test-api' }
 					rootData={ {} }
 					dataRequested={ actions.dataRequested }
 					dataReceived={ actions.dataReceived }
 				>
 					<span>Testing</span>
-				</FreshDataReduxProvider>
+				</ApiProvider>
 			);
 
-			expect( apis.test.setDataHandlers ).toHaveBeenCalledTimes( 1 );
+			expect( api.setDataHandlers ).toHaveBeenCalledTimes( 1 );
 		} );
 
-		it( 'should set api data handlers when the apis prop is updated.', () => {
+		it( 'should set api data handlers when the api prop is updated.', () => {
 			const wrapper = mount(
-				<FreshDataReduxProvider
-					apis={ {} }
+				<ApiProvider
+					api={ api }
+					apiName={ 'test-api' }
 					rootData={ {} }
 					dataRequested={ actions.dataRequested }
 					dataReceived={ actions.dataReceived }
 				>
 					<span>Testing</span>
-				</FreshDataReduxProvider>
+				</ApiProvider>
 			);
 
-			apis.test.setDataHandlers = jest.fn();
-			wrapper.setProps( { apis } );
-			expect( apis.test.setDataHandlers ).toHaveBeenCalledTimes( 1 );
+			const newApi = new TestApi();
+			newApi.setDataHandlers = jest.fn();
+			wrapper.setProps( { api: newApi } );
+			expect( newApi.setDataHandlers ).toHaveBeenCalledTimes( 1 );
 		} );
 	} );
 
 	describe( '#updateState', () => {
 		it( 'should update the states of the apis', () => {
-			apis.test.updateState = jest.fn();
+			api.updateState = jest.fn();
 
 			const now = new Date();
 			const wrapper = mount(
-				<FreshDataReduxProvider
-					apis={ apis }
+				<ApiProvider
+					api={ api }
+					apiName={ 'test-api' }
 					rootData={ {} }
 					dataRequested={ actions.dataRequested }
 					dataReceived={ actions.dataReceived }
 				>
 					<span>Testing</span>
-				</FreshDataReduxProvider>
+				</ApiProvider>
 			);
 
-			expect( apis.test.updateState ).toHaveBeenCalledTimes( 1 );
-			expect( apis.test.updateState ).toHaveBeenCalledWith( {} );
+			expect( api.updateState ).toHaveBeenCalledTimes( 1 );
+			expect( api.updateState ).toHaveBeenCalledWith( {} );
 
 			const expectedApiState = {
 				123: {
@@ -170,11 +183,11 @@ describe( 'FreshDataReduxProvider', () => {
 				},
 			};
 
-			apis.test.updateState = jest.fn();
-			wrapper.setProps( { rootData: { test: expectedApiState, } } );
+			api.updateState = jest.fn();
+			wrapper.setProps( { rootData: { 'test-api': expectedApiState, } } );
 
-			expect( apis.test.updateState ).toHaveBeenCalledTimes( 1 );
-			expect( apis.test.updateState ).toHaveBeenCalledWith( expectedApiState );
+			expect( api.updateState ).toHaveBeenCalledTimes( 1 );
+			expect( api.updateState ).toHaveBeenCalledWith( expectedApiState );
 		} );
 	} );
 
@@ -184,20 +197,21 @@ describe( 'FreshDataReduxProvider', () => {
 			const dataReceived = jest.fn();
 
 			mount(
-				<FreshDataReduxProvider
-					apis={ apis }
+				<ApiProvider
+					api={ api }
+					apiName={ 'test-api' }
 					rootData={ {} }
 					dataRequested={ dataRequested }
 					dataReceived={ dataReceived }
 				>
 					<span>Testing</span>
-				</FreshDataReduxProvider>
+				</ApiProvider>
 			);
 
-			apis.test.dataRequested( '123', [ 'thing:1', 'thing:2' ] );
+			api.dataRequested( '123', [ 'thing:1', 'thing:2' ] );
 			expect( dataReceived ).not.toHaveBeenCalled();
 			expect( dataRequested ).toHaveBeenCalledTimes( 1 );
-			expect( dataRequested ).toHaveBeenCalledWith( 'test', '123', [ 'thing:1', 'thing:2' ] );
+			expect( dataRequested ).toHaveBeenCalledWith( 'test-api', '123', [ 'thing:1', 'thing:2' ] );
 		} );
 	} );
 
@@ -207,23 +221,24 @@ describe( 'FreshDataReduxProvider', () => {
 			const dataReceived = jest.fn();
 
 			mount(
-				<FreshDataReduxProvider
-					apis={ apis }
+				<ApiProvider
+					api={ api }
+					apiName={ 'test-api' }
 					rootData={ {} }
 					dataRequested={ dataRequested }
 					dataReceived={ dataReceived }
 				>
 					<span>Testing</span>
-				</FreshDataReduxProvider>
+				</ApiProvider>
 			);
 
-			apis.test.dataReceived( '123', {
+			api.dataReceived( '123', {
 				'thing:1': { data: { color: 'blue' } },
 				'thing:2': { error: { message: 'oops!' } },
 			} );
 			expect( dataRequested ).not.toHaveBeenCalled();
 			expect( dataReceived ).toHaveBeenCalledTimes( 1 );
-			expect( dataReceived ).toHaveBeenCalledWith( 'test', '123', {
+			expect( dataReceived ).toHaveBeenCalledWith( 'test-api', '123', {
 				'thing:1': { data: { color: 'blue' } },
 				'thing:2': { error: { message: 'oops!' } },
 			} );

--- a/src/react-redux/__tests__/with-api-client.spec.js
+++ b/src/react-redux/__tests__/with-api-client.spec.js
@@ -32,10 +32,8 @@ describe( 'withApiClient', () => {
 		mapSelectorsToProps = () => ( {} );
 		getClientKey = ( { clientKey } ) => clientKey;
 
-		getApiClient = ( apiName, clientKey ) => {
-			if ( 'test' === apiName ) {
-				return api.getClient( clientKey );
-			}
+		getApiClient = ( clientKey ) => {
+			return api.getClient( clientKey );
 		};
 	} );
 
@@ -81,7 +79,7 @@ describe( 'withApiClient', () => {
 
 		it( 'should call getApiClient on mount.', () => {
 			const mockGetApiClient = jest.fn();
-			mockGetApiClient.mockReturnValue( getApiClient( 'test', '123' ) );
+			mockGetApiClient.mockReturnValue( getApiClient( '123' ) );
 			const ComponentWithApiClient = withApiClient( 'test', { mapSelectorsToProps, getClientKey } )( Component );
 			mount(
 				<ComponentWithApiClient clientKey="123" />,
@@ -89,13 +87,13 @@ describe( 'withApiClient', () => {
 			);
 
 			expect( mockGetApiClient ).toHaveBeenCalledTimes( 1 );
-			expect( mockGetApiClient ).toHaveBeenCalledWith( 'test', '123' );
+			expect( mockGetApiClient ).toHaveBeenCalledWith( '123' );
 		} );
 
 		it( 'should call getApiClient on update.', () => {
 			const mockGetApiClient = jest.fn();
-			mockGetApiClient.mockReturnValueOnce( getApiClient( 'test', '123' ) );
-			mockGetApiClient.mockReturnValueOnce( getApiClient( 'test', '456' ) );
+			mockGetApiClient.mockReturnValueOnce( getApiClient( '123' ) );
+			mockGetApiClient.mockReturnValueOnce( getApiClient( '456' ) );
 			const ComponentWithApiClient = withApiClient( 'test', { mapSelectorsToProps, getClientKey } )( Component );
 			const wrapper = mount(
 				<ComponentWithApiClient clientKey="123" />,
@@ -103,12 +101,12 @@ describe( 'withApiClient', () => {
 			);
 
 			expect( mockGetApiClient ).toHaveBeenCalledTimes( 1 );
-			expect( mockGetApiClient ).toHaveBeenLastCalledWith( 'test', '123' );
+			expect( mockGetApiClient ).toHaveBeenLastCalledWith( '123' );
 
 			wrapper.setProps( { clientKey: '456' } );
 
 			expect( mockGetApiClient ).toHaveBeenCalledTimes( 2 );
-			expect( mockGetApiClient ).toHaveBeenLastCalledWith( 'test', '456' );
+			expect( mockGetApiClient ).toHaveBeenLastCalledWith( '456' );
 		} );
 
 		it( 'should set clientKey and client in state.', () => {
@@ -119,11 +117,11 @@ describe( 'withApiClient', () => {
 
 			const state = wrapper.instance().state;
 			expect( state.clientKey ).toBe( '123' );
-			expect( state.client ).toBe( getApiClient( 'test', '123' ) );
+			expect( state.client ).toBe( getApiClient( '123' ) );
 		} );
 
 		it( 'should subscribe to the ApiClient on mount.', () => {
-			const apiClient = getApiClient( 'test', '123' );
+			const apiClient = getApiClient( '123' );
 			apiClient.subscribe = jest.fn();
 
 			const ComponentWithApiClient = withApiClient( 'test', { mapSelectorsToProps, getClientKey } )( Component );
@@ -138,7 +136,7 @@ describe( 'withApiClient', () => {
 		} );
 
 		it( 'should unsubscribe from the ApiClient on unmount.', () => {
-			const apiClient = getApiClient( 'test', '123' );
+			const apiClient = getApiClient( '123' );
 			apiClient.unsubscribe = jest.fn();
 
 			const ComponentWithApiClient = withApiClient( 'test', { mapSelectorsToProps, getClientKey } )( Component );
@@ -154,7 +152,7 @@ describe( 'withApiClient', () => {
 
 	describe( '#handleSubscriptionChange', () => {
 		it( 'should update when ApiClient state changes.', () => {
-			const apiClient = getApiClient( 'test', '123' );
+			const apiClient = getApiClient( '123' );
 
 			const ComponentWithApiClient = withApiClient( 'test', { mapSelectorsToProps, getClientKey } )( Component );
 			const wrapper = mount( <ComponentWithApiClient clientKey="123" />, { context: { getApiClient } } );
@@ -168,7 +166,7 @@ describe( 'withApiClient', () => {
 		} );
 
 		it( 'should not update when ApiClient state is identical.', () => {
-			const apiClient = getApiClient( 'test', '123' );
+			const apiClient = getApiClient( '123' );
 
 			const ComponentWithApiClient = withApiClient( 'test', { mapSelectorsToProps, getClientKey } )( Component );
 			const wrapper = mount( <ComponentWithApiClient clientKey="123" />, { context: { getApiClient } } );
@@ -185,8 +183,8 @@ describe( 'withApiClient', () => {
 		} );
 
 		it( 'should not update when set with wrong ApiClient.', () => {
-			const apiClient1 = getApiClient( 'test', '123' );
-			const apiClient2 = getApiClient( 'test', '456' );
+			const apiClient1 = getApiClient( '123' );
+			const apiClient2 = getApiClient( '456' );
 
 			const ComponentWithApiClient = withApiClient( 'test', { mapSelectorsToProps, getClientKey } )( Component );
 			const wrapper = mount( <ComponentWithApiClient clientKey="123" />, { context: { getApiClient } } );

--- a/src/react-redux/with-api-client.js
+++ b/src/react-redux/with-api-client.js
@@ -61,7 +61,7 @@ export default function withApiClient( apiName, options ) {
 						return;
 					}
 
-					const client = getApiClient( apiName, clientKey );
+					const client = getApiClient( clientKey );
 					const clientState = client.state;
 					client.subscribe( this.handleSubscriptionChange );
 					this.setState( () => {


### PR DESCRIPTION
This is the first step in simplifying fresh-data for 0.3.0 and getting
it to line up with the theory behind @wordpress/data a bit more.

It changes the provider to only support one api instead of a dictionary
of apis with their respective clients. No functionality is lost because
multiple providers can be rendered if multiple apis are needed to be
used.

To Test:
1. `npm install`, `npm test` and ensure all tests pass.

Further cumulative testing can be done with the example code testing in #81.
