### PR TITLE
Update examples for upcoming 0.3.0

### DIFF
--- a/examples/hello-world/package-lock.json
+++ b/examples/hello-world/package-lock.json
@@ -1117,6 +1117,28 @@
         "babel-types": "^6.24.1"
       }
     },
+    "babel-polyfill": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "regenerator-runtime": "^0.10.5"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.5.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+          "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+        }
+      }
+    },
     "babel-preset-env": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",

--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@fresh-data/framework": "^0.2.0",
     "ajv": "^6.5.2",
+    "babel-polyfill": "^6.26.0",
     "debug": "^3.1.0",
     "lodash": "^4.17.10",
     "react": "^16.4.1",

--- a/examples/hello-world/src/App.js
+++ b/examples/hello-world/src/App.js
@@ -14,7 +14,7 @@ const App = ( { store } ) => (
 				<header className="App-header">
 					<h1 className="App-title">Fresh Data</h1>
 				</header>
-				<Message clientKey="123" />
+				<Message />
 			</div>
 		</ApiProvider>
 	</ReduxProvider>

--- a/examples/hello-world/src/App.js
+++ b/examples/hello-world/src/App.js
@@ -3,13 +3,11 @@ import { Provider as ReduxProvider } from 'react-redux';
 import { ApiProvider } from '@fresh-data/framework';
 import './App.css';
 import Message from './Message';
-import TestApi from './test-api';
-
-const api = new TestApi();
+import testApi from './test-api';
 
 const App = ( { store } ) => (
 	<ReduxProvider store={ store } >
-		<ApiProvider apiName={ 'test-api' } api={ api }>
+		<ApiProvider apiName={ 'test-api' } api={ testApi }>
 			<div className="App">
 				<header className="App-header">
 					<h1 className="App-title">Fresh Data</h1>

--- a/examples/hello-world/src/App.js
+++ b/examples/hello-world/src/App.js
@@ -7,7 +7,7 @@ import testApi from './test-api';
 
 const App = ( { store } ) => (
 	<ReduxProvider store={ store } >
-		<ApiProvider apiName={ 'test-api' } api={ testApi }>
+		<ApiProvider apiName={ 'test-api' } apiSpec={ testApi }>
 			<div className="App">
 				<header className="App-header">
 					<h1 className="App-title">Fresh Data</h1>

--- a/examples/hello-world/src/App.js
+++ b/examples/hello-world/src/App.js
@@ -1,24 +1,22 @@
 import React from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
-import { FreshDataProvider } from '@fresh-data/framework';
+import { ApiProvider } from '@fresh-data/framework';
 import './App.css';
 import Message from './Message';
 import TestApi from './test-api';
 
-const apis = {
-	test: new TestApi(),
-};
+const api = new TestApi();
 
 const App = ( { store } ) => (
 	<ReduxProvider store={ store } >
-		<FreshDataProvider apis={ apis }>
+		<ApiProvider apiName={ 'test-api' } api={ api }>
 			<div className="App">
 				<header className="App-header">
 					<h1 className="App-title">Fresh Data</h1>
 				</header>
 				<Message clientKey="123" />
 			</div>
-		</FreshDataProvider>
+		</ApiProvider>
 	</ReduxProvider>
 );
 

--- a/examples/hello-world/src/Message.js
+++ b/examples/hello-world/src/Message.js
@@ -56,4 +56,4 @@ function mapSelectorsToProps( selectors ) {
 	};
 }
 
-export default withApiClient( 'test', { mapSelectorsToProps } )( Message );
+export default withApiClient( { mapSelectorsToProps } )( Message );

--- a/examples/hello-world/src/Message.js
+++ b/examples/hello-world/src/Message.js
@@ -56,8 +56,4 @@ function mapSelectorsToProps( selectors ) {
 	};
 }
 
-function getClientKey( ownProps ) {
-	return ownProps.clientKey;
-}
-
-export default withApiClient( 'test', { mapSelectorsToProps, getClientKey } )( Message );
+export default withApiClient( 'test', { mapSelectorsToProps } )( Message );

--- a/examples/hello-world/src/index.js
+++ b/examples/hello-world/src/index.js
@@ -4,6 +4,7 @@ import './index.css';
 import App from './App';
 import createStore from './create-store';
 import reducer from './reducer';
+import 'babel-polyfill';
 
 const store = createStore( reducer );
 

--- a/examples/hello-world/src/test-api.js
+++ b/examples/hello-world/src/test-api.js
@@ -31,27 +31,25 @@ const greetings = [
 // For demo purposes, track each request count and give an extra greeting each time.
 let requestCount = 0;
 
+export function fetchGreetings() {
+	return new Promise( ( resolve ) => {
+		requestCount++;
+		const valueCount = Math.min( requestCount, greetings.length );
+		const values = greetings.slice( 0, valueCount );
+		resolve( values );
+	} );
+}
+
 export default {
-	methods: {
-		get: ( endpointPath, params ) => { // eslint-disable-line no-unused-vars
-			return new Promise( ( resolve ) => {
-				requestCount++;
-				const valueCount = Math.min( requestCount, greetings.length );
-				const values = greetings.slice( 0, valueCount );
-				resolve( values );
-			} );
-		},
-	},
 	operations: {
-		read: ( { get } ) => ( resourceNames ) => {
+		read: ( resourceNames ) => {
 			const requests = [];
 			resourceNames.forEach( resourceName => {
 				if ( 'greetings' === resourceName ) {
-					const request = get( [ 'greetings' ] )
-						.then( data => {
-							const resources = { greetings: { data } };
-							return resources;
-						} );
+					const request = fetchGreetings().then( data => {
+						const resources = { greetings: { data } };
+						return resources;
+					} );
 					requests.push( request );
 				}
 			} );

--- a/examples/hello-world/src/test-api.js
+++ b/examples/hello-world/src/test-api.js
@@ -1,5 +1,3 @@
-import { FreshDataApi } from '@fresh-data/framework';
-
 const greetings = [
 	'Hello world!',
 	'¡Hola Mundo!',
@@ -33,8 +31,8 @@ const greetings = [
 // For demo purposes, track each request count and give an extra greeting each time.
 let requestCount = 0;
 
-export default class TestApi extends FreshDataApi {
-	methods = {
+export default {
+	methods: {
 		get: ( endpointPath, params ) => { // eslint-disable-line no-unused-vars
 			return new Promise( ( resolve ) => {
 				requestCount++;
@@ -43,9 +41,8 @@ export default class TestApi extends FreshDataApi {
 				resolve( values );
 			} );
 		},
-	}
-
-	operations = {
+	},
+	operations: {
 		read: ( { get } ) => ( resourceNames ) => {
 			const requests = [];
 			resourceNames.forEach( resourceName => {
@@ -60,12 +57,11 @@ export default class TestApi extends FreshDataApi {
 			} );
 			return requests;
 		}
-	}
-
-	selectors = {
+	},
+	selectors: {
 		getGreetings: ( getResource, requireResource ) => ( requirement ) => {
 			const resourceName = 'greetings';
 			return requireResource( requirement, resourceName ).data || [];
 		}
-	}
-}
+	},
+};

--- a/examples/hello-world/src/test-api.js
+++ b/examples/hello-world/src/test-api.js
@@ -35,7 +35,7 @@ let requestCount = 0;
 
 export default class TestApi extends FreshDataApi {
 	methods = {
-		get: ( clientKey ) => ( endpointPath, params ) => { // eslint-disable-line no-unused-vars
+		get: ( endpointPath, params ) => { // eslint-disable-line no-unused-vars
 			return new Promise( ( resolve ) => {
 				requestCount++;
 				const valueCount = Math.min( requestCount, greetings.length );

--- a/examples/wp-rest-api/package-lock.json
+++ b/examples/wp-rest-api/package-lock.json
@@ -1114,6 +1114,28 @@
         "babel-types": "^6.24.1"
       }
     },
+    "babel-polyfill": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "regenerator-runtime": "^0.10.5"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.5.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+          "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+        }
+      }
+    },
     "babel-preset-env": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",

--- a/examples/wp-rest-api/package.json
+++ b/examples/wp-rest-api/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@fresh-data/framework": "^0.2.0",
     "ajv": "^6.5.2",
+    "babel-polyfill": "^6.26.0",
     "debug": "^3.1.0",
     "html-to-react": "^1.3.3",
     "lodash": "^4.17.10",

--- a/examples/wp-rest-api/src/App.js
+++ b/examples/wp-rest-api/src/App.js
@@ -1,31 +1,23 @@
 import React from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
-import { FreshDataProvider } from '@fresh-data/framework';
 import PostList from './PostList';
 import SiteSelect from './SiteSelect';
-import WpRestApi from './test-wp-rest-api';
 import './App.css';
-
-const apis = {
-	'wp-rest-api': new WpRestApi(),
-};
 
 const App = ( { store } ) => {
 	return (
 		<ReduxProvider store={ store } >
-			<FreshDataProvider apis={ apis }>
-				<div className="App">
-					<header className="App-header">
-						<h1 className="App-title">Fresh Data</h1>
-					</header>
-					<header className="WP-header">
-						<h2><a className="WP-title" href="http://wp-api.org">WordPress REST API</a></h2>
-					</header>
-					<SiteSelect>
-						<PostList />
-					</SiteSelect>
-				</div>
-			</FreshDataProvider>
+			<div className="App">
+				<header className="App-header">
+					<h1 className="App-title">Fresh Data</h1>
+				</header>
+				<header className="WP-header">
+					<h2><a className="WP-title" href="http://wp-api.org">WordPress REST API</a></h2>
+				</header>
+				<SiteSelect>
+					<PostList />
+				</SiteSelect>
+			</div>
 		</ReduxProvider>
 	);
 };

--- a/examples/wp-rest-api/src/PostList.js
+++ b/examples/wp-rest-api/src/PostList.js
@@ -48,8 +48,4 @@ function mapSelectorsToProps( selectors ) {
 	};
 }
 
-function getClientKey( ownProps ) {
-	return ownProps.siteUrl;
-}
-
-export default withApiClient( 'wp-rest-api', { mapSelectorsToProps, getClientKey } )( PostList );
+export default withApiClient( 'wp-rest-api', { mapSelectorsToProps } )( PostList );

--- a/examples/wp-rest-api/src/PostList.js
+++ b/examples/wp-rest-api/src/PostList.js
@@ -48,4 +48,4 @@ function mapSelectorsToProps( selectors ) {
 	};
 }
 
-export default withApiClient( 'wp-rest-api', { mapSelectorsToProps } )( PostList );
+export default withApiClient( { mapSelectorsToProps } )( PostList );

--- a/examples/wp-rest-api/src/SiteSelect.js
+++ b/examples/wp-rest-api/src/SiteSelect.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { verifySiteUrl, createApi } from './test-wp-rest-api';
+import { verifySiteUrl, createApiSpec } from './test-wp-rest-api';
 import { ApiProvider } from '@fresh-data/framework';
 
 class SiteSelect extends Component {
@@ -32,12 +32,12 @@ class SiteSelect extends Component {
 		const siteUrl = url.startsWith( 'http' ) ? url : `http://${ url }`;
 
 		if ( -1 !== previousSites.indexOf( url ) ) {
-			const api = createApi( siteUrl );
+			const apiSpec = createApiSpec( siteUrl );
 
 			// We've seen this site before, don't verify.
 			this.setState( () => ( {
 				siteUrl,
-				api,
+				apiSpec,
 				isSiteValid: true,
 			} ) );
 			return;
@@ -45,11 +45,11 @@ class SiteSelect extends Component {
 
 		this.setState( () => ( { isVerifyingUrl: true } ) );
 		verifySiteUrl( siteUrl ).then( ( isSiteValid ) => {
-			const api = createApi( siteUrl );
+			const apiSpec = createApiSpec( siteUrl );
 
 			this.setState( () => ( {
 				siteUrl,
-				api,
+				apiSpec,
 				isSiteValid,
 				previousSites: [ ...previousSites, url ],
 				isVerifyingUrl: false
@@ -60,11 +60,11 @@ class SiteSelect extends Component {
 	}
 
 	renderChildren() {
-		const { api, siteUrl } = this.state;
+		const { apiSpec, siteUrl } = this.state;
 		const { children } = this.props;
 		return (
-			<ApiProvider apiName={ siteUrl } api={ api }>
-				{ React.Children.map( children, child => React.cloneElement( child, { siteUrl } ) ) }
+			<ApiProvider apiName={ siteUrl } apiSpec={ apiSpec }>
+				{ children }
 			</ApiProvider>
 		);
 	}

--- a/examples/wp-rest-api/src/SiteSelect.js
+++ b/examples/wp-rest-api/src/SiteSelect.js
@@ -32,8 +32,7 @@ class SiteSelect extends Component {
 		const siteUrl = url.startsWith( 'http' ) ? url : `http://${ url }`;
 
 		if ( -1 !== previousSites.indexOf( url ) ) {
-			const ApiClass = createApi( siteUrl );
-			const api = new ApiClass();
+			const api = createApi( siteUrl );
 
 			// We've seen this site before, don't verify.
 			this.setState( () => ( {
@@ -46,8 +45,7 @@ class SiteSelect extends Component {
 
 		this.setState( () => ( { isVerifyingUrl: true } ) );
 		verifySiteUrl( siteUrl ).then( ( isSiteValid ) => {
-			const ApiClass = createApi( siteUrl );
-			const api = new ApiClass();
+			const api = createApi( siteUrl );
 
 			this.setState( () => ( {
 				siteUrl,
@@ -65,7 +63,7 @@ class SiteSelect extends Component {
 		const { api, siteUrl } = this.state;
 		const { children } = this.props;
 		return (
-			<ApiProvider apiName={ 'wp-site' } api={ api }>
+			<ApiProvider apiName={ siteUrl } api={ api }>
 				{ React.Children.map( children, child => React.cloneElement( child, { siteUrl } ) ) }
 			</ApiProvider>
 		);

--- a/examples/wp-rest-api/src/http-fetch.js
+++ b/examples/wp-rest-api/src/http-fetch.js
@@ -1,0 +1,22 @@
+import qs from 'qs';
+
+export const get = ( fetch, baseUrl ) => ( endpointPath, params ) => {
+	const path = endpointPath.join( '/' );
+	const httpParams = { page: params.page, per_page: params.perPage }; // eslint-disable-line camelcase
+	const url = `${ baseUrl }/${ path }${ httpParams ? '?' + qs.stringify( httpParams ) : '' }`;
+
+	return fetch( url ).then( ( response ) => {
+		if ( ! response.ok ) {
+			throw new Error( `HTTP Error for ${ response.url }: ${ response.status }` );
+		}
+		return response.json().then( ( data ) => {
+			return data;
+		} );
+	} );
+};
+
+export default ( baseUrl, fetch = window.fetch ) => {
+	return {
+		get: get( fetch, baseUrl ),
+	};
+};

--- a/examples/wp-rest-api/src/index.js
+++ b/examples/wp-rest-api/src/index.js
@@ -4,6 +4,7 @@ import './index.css';
 import App from './App';
 import createStore from './create-store';
 import reducer from './reducer';
+import 'babel-polyfill';
 
 const store = createStore( reducer );
 

--- a/examples/wp-rest-api/src/test-wp-rest-api.js
+++ b/examples/wp-rest-api/src/test-wp-rest-api.js
@@ -5,11 +5,11 @@ import qs from 'qs';
 const NAMESPACE = 'wp/v2';
 const API_URL_PREFIX = `wp-json/${ NAMESPACE }`;
 
-export function createApi( fetch = window.fetch ) {
+export function createApi( siteUrl, fetch = window.fetch ) {
 	class TestWPRestApi extends FreshDataApi {
 		methods = {
 			get: ( clientKey ) => ( endpointPath, params ) => { // eslint-disable-line no-unused-vars
-				const baseUrl = `${ clientKey }/${ API_URL_PREFIX }`;
+				const baseUrl = `${ siteUrl }/${ API_URL_PREFIX }`;
 				const path = endpointPath.join( '/' );
 				const httpParams = { page: params.page, per_page: params.perPage }; // eslint-disable-line camelcase
 				const url = `${ baseUrl }/${ path }${ httpParams ? '?' + qs.stringify( httpParams ) : '' }`;
@@ -100,5 +100,3 @@ export function verifySiteUrl( siteUrl, fetch = window.fetch ) {
 		} );
 	} );
 }
-
-export default createApi();

--- a/examples/wp-rest-api/src/test-wp-rest-api.js
+++ b/examples/wp-rest-api/src/test-wp-rest-api.js
@@ -8,7 +8,7 @@ const API_URL_PREFIX = `wp-json/${ NAMESPACE }`;
 export function createApi( siteUrl, fetch = window.fetch ) {
 	class TestWPRestApi extends FreshDataApi {
 		methods = {
-			get: ( clientKey ) => ( endpointPath, params ) => { // eslint-disable-line no-unused-vars
+			get: ( endpointPath, params ) => { // eslint-disable-line no-unused-vars
 				const baseUrl = `${ siteUrl }/${ API_URL_PREFIX }`;
 				const path = endpointPath.join( '/' );
 				const httpParams = { page: params.page, per_page: params.perPage }; // eslint-disable-line camelcase
@@ -48,7 +48,7 @@ export function createApi( siteUrl, fetch = window.fetch ) {
 			}
 		}
 	}
-	return TestWPRestApi;
+	return new TestWPRestApi();
 }
 
 export function readPostPages( get, resourceNames ) {

--- a/examples/wp-rest-api/src/test-wp-rest-api.js
+++ b/examples/wp-rest-api/src/test-wp-rest-api.js
@@ -1,13 +1,12 @@
 import { startsWith } from 'lodash';
-import { FreshDataApi } from '@fresh-data/framework';
 import qs from 'qs';
 
 const NAMESPACE = 'wp/v2';
 const API_URL_PREFIX = `wp-json/${ NAMESPACE }`;
 
 export function createApi( siteUrl, fetch = window.fetch ) {
-	class TestWPRestApi extends FreshDataApi {
-		methods = {
+	return {
+		methods: {
 			get: ( endpointPath, params ) => { // eslint-disable-line no-unused-vars
 				const baseUrl = `${ siteUrl }/${ API_URL_PREFIX }`;
 				const path = endpointPath.join( '/' );
@@ -23,15 +22,13 @@ export function createApi( siteUrl, fetch = window.fetch ) {
 					} );
 				} );
 			},
-		}
-
-		operations = {
+		},
+		operations: {
 			read: ( { get } ) => ( resourceNames ) => {
 				return readPostPages( get, resourceNames );
 			},
-		}
-
-		selectors = {
+		},
+		selectors: {
 			getPostsPage: ( getResource, requireResource ) => ( requirement, params ) => {
 				const paramsString = JSON.stringify( params, Object.keys( params ).sort() );
 				const resourceName = 'posts-page:' + paramsString;
@@ -46,9 +43,8 @@ export function createApi( siteUrl, fetch = window.fetch ) {
 				const { data, lastRequested, lastReceived = -Infinity } = getResource( resourceName );
 				return ( ! data || ( lastRequested && lastRequested > lastReceived ) );
 			}
-		}
-	}
-	return new TestWPRestApi();
+		},
+	};
 }
 
 export function readPostPages( get, resourceNames ) {

--- a/examples/wp-rest-api/src/test-wp-rest-api.js
+++ b/examples/wp-rest-api/src/test-wp-rest-api.js
@@ -4,7 +4,7 @@ import qs from 'qs';
 const NAMESPACE = 'wp/v2';
 const API_URL_PREFIX = `wp-json/${ NAMESPACE }`;
 
-export function createApi( siteUrl, fetch = window.fetch ) {
+export function createApiSpec( siteUrl, fetch = window.fetch ) {
 	return {
 		methods: {
 			get: ( endpointPath, params ) => { // eslint-disable-line no-unused-vars

--- a/examples/wp-rest-api/src/test-wp-rest-api.js
+++ b/examples/wp-rest-api/src/test-wp-rest-api.js
@@ -1,30 +1,16 @@
 import { startsWith } from 'lodash';
-import qs from 'qs';
+import httpMethods from './http-fetch';
 
 const NAMESPACE = 'wp/v2';
 const API_URL_PREFIX = `wp-json/${ NAMESPACE }`;
 
-export function createApiSpec( siteUrl, fetch = window.fetch ) {
-	return {
-		methods: {
-			get: ( endpointPath, params ) => { // eslint-disable-line no-unused-vars
-				const baseUrl = `${ siteUrl }/${ API_URL_PREFIX }`;
-				const path = endpointPath.join( '/' );
-				const httpParams = { page: params.page, per_page: params.perPage }; // eslint-disable-line camelcase
-				const url = `${ baseUrl }/${ path }${ httpParams ? '?' + qs.stringify( httpParams ) : '' }`;
+export function createApiSpec( siteUrl, methods = httpMethods ) {
+	const baseUrl = `${ siteUrl }/${ API_URL_PREFIX }`;
+	const { get } = methods( baseUrl );
 
-				return fetch( url ).then( ( response ) => {
-					if ( ! response.ok ) {
-						throw new Error( `HTTP Error for ${ response.url }: ${ response.status }` );
-					}
-					return response.json().then( ( data ) => {
-						return data;
-					} );
-				} );
-			},
-		},
+	return {
 		operations: {
-			read: ( { get } ) => ( resourceNames ) => {
+			read: ( resourceNames ) => {
 				return readPostPages( get, resourceNames );
 			},
 		},


### PR DESCRIPTION
This updates the example code to work with the following changes:
 * #80 : Simplified provider that only holds a single api.

To Test:
0. `npm install`, `npm run build`, `npm link`.

For `examples/hello-world` and `examples/wp-rest-api`:
1. cd to example/xxx directory
2. `npm install`, `npm link @fresh-data/framework`, `npm start`
3. Verify operation of each example after it loads from `localhost:3000`
