### PR TITLE
Remove clientKey

### DIFF
--- a/src/api/__tests__/index.spec.js
+++ b/src/api/__tests__/index.spec.js
@@ -3,9 +3,9 @@ import FreshDataApi from '../index';
 
 describe( 'api', () => {
 	describe( '#constructor', () => {
-		it( 'should initialize clients map', () => {
+		it( 'should initialize client to null', () => {
 			const api = new FreshDataApi();
-			expect( api.clients ).toEqual( new Map() );
+			expect( api.client ).toBeNull();
 		} );
 
 		it( 'should initialize state', () => {
@@ -39,53 +39,10 @@ describe( 'api', () => {
 			class MyApi extends FreshDataApi {
 			}
 			const api = new MyApi();
-			const client = api.createClient( 'myKey' );
+			const client = api.createClient();
 
 			expect( client ).toBeInstanceOf( ApiClient );
-			expect( client.key ).toBe( 'myKey' );
-			expect( api.clients.size ).toBe( 1 );
-			expect( api.clients.get( 'myKey' ) ).toEqual( client );
-		} );
-
-		it( 'should not create a client if the key is null', () => {
-			class MyApi extends FreshDataApi {
-			}
-			const api = new MyApi();
-			const client = api.createClient( null );
-
-			expect( client ).toBeNull();
-		} );
-
-		it( 'should not create a client if the key is undefined', () => {
-			class MyApi extends FreshDataApi {
-			}
-			const api = new MyApi();
-			const client = api.createClient( undefined );
-
-			expect( client ).toBeNull();
-		} );
-	} );
-
-	describe( '#findClient', () => {
-		it( 'should find an existing client', () => {
-			class MyApi extends FreshDataApi {
-			}
-			const api = new MyApi();
-			const client = api.createClient( 'myKey' );
-			const foundClient = api.findClient( 'myKey' );
-
-			expect( foundClient ).toBe( client );
-		} );
-
-		it( 'should not find an existing client', () => {
-			class MyApi extends FreshDataApi {
-			}
-			const api = new MyApi();
-			const client = api.createClient( 'myKey' );
-			const foundClient = api.findClient( 'myKeey' );
-
-			expect( foundClient ).not.toBe( client );
-			expect( foundClient ).toBeNull();
+			expect( api.client ).toBe( client );
 		} );
 	} );
 
@@ -94,23 +51,21 @@ describe( 'api', () => {
 			class MyApi extends FreshDataApi {
 			}
 			const api = new MyApi();
-			const client = api.createClient( 'myKey' );
-			const foundClient = api.getClient( 'myKey' );
+			const client = api.createClient();
+			const foundClient = api.getClient();
 
 			expect( foundClient ).toBe( client );
-			expect( api.clients.size ).toBe( 1 );
+			expect( api.client ).toBe( client );
 		} );
 
 		it( 'should create a non-existing client', () => {
 			class MyApi extends FreshDataApi {
 			}
 			const api = new MyApi();
-			const client = api.getClient( 'myKey' );
+			const client = api.getClient();
 
 			expect( client ).toBeInstanceOf( ApiClient );
-			expect( client.key ).toBe( 'myKey' );
-			expect( api.clients.size ).toBe( 1 );
-			expect( api.clients.get( 'myKey' ) ).toEqual( client );
+			expect( api.client ).toBe( client );
 		} );
 	} );
 
@@ -126,76 +81,47 @@ describe( 'api', () => {
 			expect( api.state ).toBe( state );
 		} );
 
-		it( 'should update state for each client', () => {
-			const client1State = {};
-			const client2State = {};
-			const state = { client1: client1State, client2: client2State };
+		it( 'should update state for the client', () => {
+			const state = {};
 			class MyApi extends FreshDataApi {
 			}
 			const api = new MyApi();
-			const client1 = api.getClient( 'client1' );
-			const client2 = api.getClient( 'client2' );
+			const client = api.getClient();
 
 			api.updateState( state );
 
 			expect( api.state ).toBe( state );
-			expect( client1.state ).toBe( client1State );
-			expect( client2.state ).toBe( client2State );
+			expect( client.state ).toBe( state );
 		} );
 
-		it( 'should only set client state if state is not identical', () => {
-			const client1State = { client1: 1 };
-			const client1State2 = { client1: 2 };
-			const client2State = { client2: 1 };
-			const state = { client1: client1State, client2: client2State };
+		it( 'should only set state if state is not identical', () => {
+			const state1 = { value: 1 };
+			const state2 = { value: 1 };
 			class MyApi extends FreshDataApi {
 			}
 			const api = new MyApi();
-			const client1 = api.getClient( 'client1' );
-			const client2 = api.getClient( 'client2' );
-			api.updateState( state );
+			const client = api.getClient();
+			api.updateState( state1 );
 
-			client1.setState = jest.fn();
-			client2.setState = jest.fn();
-			api.updateState( state );
+			client.setState = jest.fn();
+			api.updateState( state1 );
 
-			expect( client1.setState ).not.toHaveBeenCalled();
-			expect( client2.setState ).not.toHaveBeenCalled();
+			expect( client.setState ).not.toHaveBeenCalled();
 
-			client1.setState = jest.fn();
-			client2.setState = jest.fn();
-			api.updateState( { client1: client1State2, client2: client2State } );
+			client.setState = jest.fn();
+			api.updateState( state2 );
 
-			expect( client1.setState ).toHaveBeenCalledTimes( 1 );
-			expect( client1.setState ).toHaveBeenCalledWith( client1State2 );
-			expect( client2.setState ).not.toHaveBeenCalled();
-		} );
-
-		it( 'should set default state for client', () => {
-			const client1State = {};
-			const state = { client1: client1State };
-			class MyApi extends FreshDataApi {
-			}
-			const api = new MyApi();
-			const client1 = api.getClient( 'client1' );
-			const client2 = api.getClient( 'client2' );
-
-			api.updateState( state );
-
-			expect( api.state ).toBe( state );
-			expect( client1.state ).toBe( client1State );
-			expect( client2.state ).toEqual( {} );
+			expect( client.setState ).toHaveBeenCalledTimes( 1 );
+			expect( client.setState ).toHaveBeenCalledWith( state2 );
 		} );
 	} );
 
 	describe( '#dataRequested', () => {
-		const clientKey = 'client1';
-
 		it( 'should do nothing if dataRequested is not set.', () => {
 			class MyApi extends FreshDataApi {
 			}
 			const api = new MyApi();
-			api.dataRequested( clientKey, [ 'thing:2' ] );
+			api.dataRequested( [ 'thing:2' ] );
 		} );
 
 		it( 'should call dataRequested', () => {
@@ -205,11 +131,11 @@ describe( 'api', () => {
 			}
 			const api = new MyApi();
 			api.setDataHandlers( { dataRequested, dataReceived } );
-			api.dataRequested( clientKey, [ 'thing:3', 'thing:4' ] );
+			api.dataRequested( [ 'thing:3', 'thing:4' ] );
 
 			expect( dataReceived ).not.toHaveBeenCalled();
 			expect( dataRequested ).toHaveBeenCalledTimes( 1 );
-			expect( dataRequested ).toHaveBeenCalledWith( api, clientKey, [ 'thing:3', 'thing:4' ] );
+			expect( dataRequested ).toHaveBeenCalledWith( [ 'thing:3', 'thing:4' ] );
 		} );
 
 		it( 'should return resourceNames given', () => {
@@ -222,18 +148,16 @@ describe( 'api', () => {
 			const api = new MyApi();
 			api.setDataHandlers( { dataRequested } );
 
-			expect( api.dataRequested( clientKey, resourceNames ) ).toBe( resourceNames );
+			expect( api.dataRequested( resourceNames ) ).toBe( resourceNames );
 		} );
 	} );
 
 	describe( '#dataReceived', () => {
-		const clientKey = 'client1';
-
 		it( 'should do nothing if dataReceived is not set.', () => {
 			class MyApi extends FreshDataApi {
 			}
 			const api = new MyApi();
-			api.dataReceived( clientKey, { 'thing:2': { data: { color: 'grey' } } } );
+			api.dataReceived( { 'thing:2': { data: { color: 'grey' } } } );
 		} );
 
 		it( 'should call dataReceived', () => {
@@ -243,14 +167,14 @@ describe( 'api', () => {
 			}
 			const api = new MyApi();
 			api.setDataHandlers( { dataRequested, dataReceived } );
-			api.dataReceived( clientKey, {
+			api.dataReceived( {
 				'thing:3': { data: { color: 'grey' } },
 				'thing:4': { error: { message: 'oops' } }
 			} );
 
 			expect( dataRequested ).not.toHaveBeenCalled();
 			expect( dataReceived ).toHaveBeenCalledTimes( 1 );
-			expect( dataReceived ).toHaveBeenCalledWith( api, clientKey, {
+			expect( dataReceived ).toHaveBeenCalledWith( {
 				'thing:3': { data: { color: 'grey' } },
 				'thing:4': { error: { message: 'oops' } },
 			} );
@@ -268,7 +192,7 @@ describe( 'api', () => {
 			};
 
 			api.setDataHandlers( { dataRequested, dataReceived } );
-			expect( api.dataReceived( clientKey, resources ) ).toBe( resources );
+			expect( api.dataReceived( resources ) ).toBe( resources );
 		} );
 	} );
 

--- a/src/client/__tests__/index.spec.js
+++ b/src/client/__tests__/index.spec.js
@@ -38,20 +38,20 @@ describe( 'ApiClient', () => {
 	};
 
 	it( 'should initialize to empty state', () => {
-		const apiClient = new ApiClient( emptyApi, '123' );
+		const apiClient = new ApiClient( emptyApi );
 		expect( apiClient.state ).toEqual( {} );
 	} );
 
 	it( 'should set state', () => {
 		const clientState = { resources: {} };
-		const apiClient = new ApiClient( emptyApi, '123' );
+		const apiClient = new ApiClient( emptyApi );
 		apiClient.setState( clientState );
 		expect( apiClient.state ).toBe( clientState );
 	} );
 
 	it( 'should update timer on set state', () => {
 		const clientState = { resources: {} };
-		const apiClient = new ApiClient( emptyApi, '123' );
+		const apiClient = new ApiClient( emptyApi );
 		apiClient.updateTimer = jest.fn();
 		apiClient.setState( clientState );
 		expect( apiClient.updateTimer ).toHaveBeenCalledTimes( 1 );
@@ -59,7 +59,7 @@ describe( 'ApiClient', () => {
 
 	it( 'should not set state twice', () => {
 		const clientState = { resources: {} };
-		const apiClient = new ApiClient( emptyApi, '123' );
+		const apiClient = new ApiClient( emptyApi );
 		apiClient.updateTimer = jest.fn();
 		apiClient.setState( clientState );
 		expect( apiClient.updateTimer ).toHaveBeenCalledTimes( 1 );
@@ -69,29 +69,17 @@ describe( 'ApiClient', () => {
 		expect( apiClient.updateTimer ).not.toHaveBeenCalled();
 	} );
 
-	it( 'should map api methods to client key', () => {
-		const checkMethod = jest.fn();
+	it( 'should set api methods', () => {
 		class TestApi extends FreshDataApi {
 			methods = {
-				get: ( clientKey ) => ( endpointPath ) => ( params ) => {
-					checkMethod( 'get', clientKey, endpointPath, params );
-				},
-				post: ( clientKey ) => ( endpointPath ) => ( params ) => {
-					checkMethod( 'post', clientKey, endpointPath, params );
-				},
+				get: () => {},
+				post: () => {},
 			}
 		}
 		const api = new TestApi();
-		const apiClient = new ApiClient( api, '123' );
+		const apiClient = new ApiClient( api );
 
-		const thingsPath = [ 'things' ];
-		const pageParams = { page: 1, perPage: 3 };
-		apiClient.methods.get( thingsPath )( pageParams );
-		expect( checkMethod ).toHaveBeenCalledWith( 'get', '123', thingsPath, pageParams );
-
-		const thing2Path = [ 'things', 2 ];
-		apiClient.methods.post( thing2Path )();
-		expect( checkMethod ).toHaveBeenCalledWith( 'post', '123', thing2Path, undefined );
+		expect( apiClient.methods ).toBe( api.methods );
 	} );
 
 	it( 'should map operations to methods', () => {
@@ -108,7 +96,7 @@ describe( 'ApiClient', () => {
 			}
 		}
 		const api = new TestApi();
-		const apiClient = new ApiClient( api, '123' );
+		const apiClient = new ApiClient( api );
 
 		apiClient.operations.read( [ 'thing:1' ], { color: 'red' } );
 		expect( checkOperation ).toHaveBeenCalledWith( apiClient.methods, [ 'thing:1' ], { color: 'red' } );
@@ -126,7 +114,7 @@ describe( 'ApiClient', () => {
 		}
 
 		const api = new TestApi();
-		const apiClient = new ApiClient( api, '123' );
+		const apiClient = new ApiClient( api );
 
 		expect( createThing ).toHaveBeenCalledTimes( 1 );
 		expect( createThing ).toHaveBeenCalledWith( apiClient.operations );
@@ -138,7 +126,7 @@ describe( 'ApiClient', () => {
 			selectors = thingSelectors;
 		}
 		const api = new TestApi();
-		const apiClient = new ApiClient( api, '123' );
+		const apiClient = new ApiClient( api );
 		apiClient.setState( thing1ClientState );
 
 		const dataThing1 = apiClient.getResource( 'thing:1' ).data;
@@ -155,7 +143,7 @@ describe( 'ApiClient', () => {
 			class TestApi extends FreshDataApi {
 			}
 			const api = new TestApi();
-			const apiClient = new ApiClient( api, '123' );
+			const apiClient = new ApiClient( api );
 			expect( apiClient.getResource( 'nonexistentResource:1' ) ).toEqual( {} );
 		} );
 
@@ -163,7 +151,7 @@ describe( 'ApiClient', () => {
 			class TestApi extends FreshDataApi {
 			}
 			const api = new TestApi();
-			const apiClient = new ApiClient( api, '123' );
+			const apiClient = new ApiClient( api );
 			apiClient.setState( { resources: { 'thing:1': { lastRequested: now, data: { foot: 'red' } } } } );
 			expect( apiClient.getResource( 'thing:1' ) ).toEqual( { lastRequested: now, data: { foot: 'red' } } );
 		} );
@@ -174,7 +162,7 @@ describe( 'ApiClient', () => {
 			class TestApi extends FreshDataApi {
 			}
 			const api = new TestApi();
-			const apiClient = new ApiClient( api, '123' );
+			const apiClient = new ApiClient( api );
 			expect( apiClient.requireResource( [] )( {}, 'nonexistentResource:1' ) ).toEqual( {} );
 		} );
 
@@ -182,7 +170,7 @@ describe( 'ApiClient', () => {
 			class TestApi extends FreshDataApi {
 			}
 			const api = new TestApi();
-			const apiClient = new ApiClient( api, '123' );
+			const apiClient = new ApiClient( api );
 			apiClient.setState( { resources: { 'thing:1': { lastRequested: now, data: { foot: 'red' } } } } );
 			expect( apiClient.requireResource( [] )( {}, 'thing:1' ) ).toEqual( { lastRequested: now, data: { foot: 'red' } } );
 		} );
@@ -191,7 +179,7 @@ describe( 'ApiClient', () => {
 			class TestApi extends FreshDataApi {
 			}
 			const api = new TestApi();
-			const apiClient = new ApiClient( api, '123' );
+			const apiClient = new ApiClient( api );
 			const requirement = { freshness: 5 * SECOND };
 			const componentRequirements = [];
 			apiClient.requireResource( componentRequirements )( requirement, 'thing:1' );
@@ -202,7 +190,7 @@ describe( 'ApiClient', () => {
 			class TestApi extends FreshDataApi {
 			}
 			const api = new TestApi();
-			const apiClient = new ApiClient( api, '123' );
+			const apiClient = new ApiClient( api );
 			const requirement = { freshness: 5 * SECOND };
 			const componentRequirements = [ { freshness: 2 * SECOND, resourceName: 'thing:1' } ];
 			apiClient.requireResource( componentRequirements )( requirement, 'thing:1' );
@@ -223,7 +211,7 @@ describe( 'ApiClient', () => {
 		let apiClient = null;
 
 		beforeEach( () => {
-			apiClient = new ApiClient( api, '123' );
+			apiClient = new ApiClient( api );
 		} );
 
 		afterEach( () => {
@@ -298,7 +286,7 @@ describe( 'ApiClient', () => {
 			const setTimer = jest.fn();
 			setTimer.mockReturnValue( 5 ); // return a timeout id.
 			const clearTimer = jest.fn();
-			const apiClient = new ApiClient( emptyApi, '123', setTimer, clearTimer );
+			const apiClient = new ApiClient( emptyApi, setTimer, clearTimer );
 			apiClient.updateTimer( now, 5000 );
 
 			expect( apiClient.timeoutId ).toBe( 5 );
@@ -315,7 +303,7 @@ describe( 'ApiClient', () => {
 			const setTimer = jest.fn();
 			setTimer.mockReturnValue( 5 ); // return a timeout id.
 			const clearTimer = jest.fn();
-			const apiClient = new ApiClient( api, '123', setTimer, clearTimer );
+			const apiClient = new ApiClient( api, setTimer, clearTimer );
 
 			const component = () => {};
 			apiClient.setComponentData( component, ( selectors ) => {
@@ -335,7 +323,7 @@ describe( 'ApiClient', () => {
 			const setTimer = jest.fn();
 			setTimer.mockReturnValue( 5 ); // return a timeout id.
 			const clearTimer = jest.fn();
-			const apiClient = new ApiClient( emptyApi, '123', setTimer, clearTimer );
+			const apiClient = new ApiClient( emptyApi, setTimer, clearTimer );
 
 			apiClient.updateTimer( now );
 
@@ -355,7 +343,7 @@ describe( 'ApiClient', () => {
 		let apiClient = null;
 
 		beforeEach( () => {
-			apiClient = new ApiClient( api, '123' );
+			apiClient = new ApiClient( api );
 			apiClient.setState( thing1ClientState );
 		} );
 
@@ -381,7 +369,7 @@ describe( 'ApiClient', () => {
 		} );
 
 		it( 'should handle an empty state.', () => {
-			apiClient = new ApiClient( api, '123' );
+			apiClient = new ApiClient( api );
 			apiClient.operations.read = jest.fn();
 			apiClient.setComponentData( component, ( selectors ) => {
 				selectors.getThing( { freshness: 90 * SECOND }, 3 );
@@ -490,7 +478,7 @@ describe( 'ApiClient', () => {
 				}
 			}
 			api = new TestApi();
-			apiClient = new ApiClient( api, '123' );
+			apiClient = new ApiClient( api );
 		} );
 
 		it( 'should call the corresponding api operation handlers.', () => {
@@ -504,7 +492,7 @@ describe( 'ApiClient', () => {
 				}
 			}
 			api = new TestApi();
-			apiClient = new ApiClient( api, '123' );
+			apiClient = new ApiClient( api );
 
 			apiClient.applyOperation( 'read', [ 'thing:1' ], { data: true } );
 			expect( readFunc ).toHaveBeenCalledWith( api.methods, [ 'thing:1' ], { data: true } );
@@ -514,7 +502,7 @@ describe( 'ApiClient', () => {
 			class TestApi extends FreshDataApi {
 			}
 			api = new TestApi();
-			apiClient = new ApiClient( api, '123' );
+			apiClient = new ApiClient( api );
 
 			expect( () => apiClient.applyOperation( 'read', [ 'thing:1' ] ) ).toThrowError();
 		} );
@@ -528,7 +516,7 @@ describe( 'ApiClient', () => {
 				}
 			}
 			api = new TestApi();
-			apiClient = new ApiClient( api, '123' );
+			apiClient = new ApiClient( api );
 
 			apiClient.applyOperation( 'read', [ 'thing:1' ] );
 		} );
@@ -545,7 +533,7 @@ describe( 'ApiClient', () => {
 			api.dataRequested = dataRequested;
 			apiClient.applyOperation( 'read', resourceNames, data );
 			expect( dataRequested ).toHaveBeenCalledTimes( 1 );
-			expect( dataRequested ).toHaveBeenCalledWith( '123', resourceNames );
+			expect( dataRequested ).toHaveBeenCalledWith( resourceNames );
 		} );
 
 		it( 'should call dataReceived for each resource received from either an object or promise.', () => {
@@ -555,10 +543,10 @@ describe( 'ApiClient', () => {
 			api.dataReceived = dataReceived;
 			apiClient.applyOperation( 'read', resourceNames ).then( () => {
 				expect( dataReceived ).toHaveBeenCalledTimes( 2 );
-				expect( dataReceived ).toHaveBeenCalledWith( '123', {
+				expect( dataReceived ).toHaveBeenCalledWith( {
 					'type:1': { data: { attribute: 'some' } },
 				} );
-				expect( dataReceived ).toHaveBeenCalledWith( '123', {
+				expect( dataReceived ).toHaveBeenCalledWith( {
 					'thing:2': { data: { color: 'blue' } },
 					'thing:3': { data: { color: 'green' } },
 				} );
@@ -574,14 +562,14 @@ describe( 'ApiClient', () => {
 				}
 			}
 			api = new TestApi();
-			apiClient = new ApiClient( api, '123' );
+			apiClient = new ApiClient( api );
 			const unhandled = jest.fn();
 
 			api.unhandledErrorReceived = unhandled;
 			apiClient.applyOperation( 'read', [ 'thing:1' ] ).then( () => {
 			} ).catch( ( error ) => {
 				expect( unhandled ).toHaveBeenCalledTimes( 1 );
-				expect( unhandled ).toHaveBeenCalledWith( '123', 'read', [ 'thing:1' ], new Error( 'BOOM!' ) );
+				expect( unhandled ).toHaveBeenCalledWith( 'read', [ 'thing:1' ], new Error( 'BOOM!' ) );
 				expect( error ).toEqual( new Error( 'BOOM!' ) );
 			} );
 		} );
@@ -613,7 +601,7 @@ describe( 'ApiClient', () => {
 	describe( '#subscribe', () => {
 		it( 'should add a callback to the subscription list.', () => {
 			const dummyApi = new FreshDataApi();
-			const apiClient = new ApiClient( dummyApi, '123' );
+			const apiClient = new ApiClient( dummyApi );
 			const callback = jest.fn();
 
 			expect( apiClient.subscriptionCallbacks.size ).toBe( 0 );
@@ -627,7 +615,7 @@ describe( 'ApiClient', () => {
 
 		it( 'should not add a callback multiple times.', () => {
 			const dummyApi = new FreshDataApi();
-			const apiClient = new ApiClient( dummyApi, '123' );
+			const apiClient = new ApiClient( dummyApi );
 			const callback = jest.fn();
 
 			expect( apiClient.subscribe( callback ) ).toBe( callback );
@@ -639,7 +627,7 @@ describe( 'ApiClient', () => {
 
 		it( 'should remove a callback to the subscription list.', () => {
 			const dummyApi = new FreshDataApi();
-			const apiClient = new ApiClient( dummyApi, '123' );
+			const apiClient = new ApiClient( dummyApi );
 			const callback = jest.fn();
 
 			apiClient.subscribe( callback );
@@ -651,7 +639,7 @@ describe( 'ApiClient', () => {
 
 		it( 'should not attempt remove a callback twice.', () => {
 			const dummyApi = new FreshDataApi();
-			const apiClient = new ApiClient( dummyApi, '123' );
+			const apiClient = new ApiClient( dummyApi );
 			const callback = jest.fn();
 
 			apiClient.subscribe( callback );
@@ -663,7 +651,7 @@ describe( 'ApiClient', () => {
 
 		it( 'should call the callback whenever state is set on the client.', () => {
 			const dummyApi = new FreshDataApi();
-			const apiClient = new ApiClient( dummyApi, '123' );
+			const apiClient = new ApiClient( dummyApi );
 			const callback = jest.fn();
 			const state = {};
 

--- a/src/react-redux/__tests__/actions.spec.js
+++ b/src/react-redux/__tests__/actions.spec.js
@@ -3,7 +3,6 @@ import { FRESH_DATA_RECEIVED, FRESH_DATA_REQUESTED } from '../action-types.js';
 
 describe( 'actions', () => {
 	const apiName = 'myApiName';
-	const clientKey = 'myClientKey';
 	const resourceNames = [ 'thing:1', 'thing:2' ];
 	const resources = {
 		'thing:1': { data: { attributes: { attr1: '1', attr2: '2', attr3: 3 } } },
@@ -13,36 +12,34 @@ describe( 'actions', () => {
 
 	describe( 'dataRequested', () => {
 		it( 'should create a simple action object with expected fields.', () => {
-			const action = dataRequested( apiName, clientKey, resourceNames, time );
+			const action = dataRequested( apiName, resourceNames, time );
 			expect( action ).toEqual( {
 				type: FRESH_DATA_REQUESTED,
 				apiName,
-				clientKey,
 				resourceNames,
 				time,
 			} );
 		} );
 
 		it( 'should set a default time if none given.', () => {
-			const action = dataRequested( apiName, clientKey, resourceNames );
+			const action = dataRequested( apiName, resourceNames );
 			expect( action.time ).toBeInstanceOf( Date );
 		} );
 	} );
 
 	describe( 'dataReceived', () => {
 		it( 'should create a simple action object with expected fields.', () => {
-			const action = dataReceived( apiName, clientKey, resources, time );
+			const action = dataReceived( apiName, resources, time );
 			expect( action ).toEqual( {
 				type: FRESH_DATA_RECEIVED,
 				apiName,
-				clientKey,
 				resources,
 				time,
 			} );
 		} );
 
 		it( 'should set a default time if none given.', () => {
-			const action = dataReceived( apiName, clientKey, resources );
+			const action = dataReceived( apiName, resources );
 			expect( action.time ).toBeInstanceOf( Date );
 		} );
 	} );

--- a/src/react-redux/__tests__/provider.spec.js
+++ b/src/react-redux/__tests__/provider.spec.js
@@ -70,7 +70,7 @@ describe( 'ApiProvider', () => {
 					<span>Testing</span>
 				</ApiProvider>
 			);
-			expect( wrapper.instance().getApiClient( '123' ) ).toBeInstanceOf( ApiClient );
+			expect( wrapper.instance().getApiClient() ).toBeInstanceOf( ApiClient );
 		} );
 
 		it( 'should return already created api client.', () => {
@@ -85,8 +85,8 @@ describe( 'ApiProvider', () => {
 					<span>Testing</span>
 				</ApiProvider>
 			);
-			const apiClient = wrapper.instance().getApiClient( '123' );
-			expect( wrapper.instance().getApiClient( '123' ) ).toBe( apiClient );
+			const apiClient = wrapper.instance().getApiClient();
+			expect( wrapper.instance().getApiClient() ).toBe( apiClient );
 		} );
 
 		it( 'should return undefined if no api prop is set.', () => {
@@ -105,7 +105,7 @@ describe( 'ApiProvider', () => {
 					<span>Testing</span>
 				</ApiProviderOptionalPropTypes>
 			);
-			expect( wrapper.instance().getApiClient( '123' ) ).toBeUndefined();
+			expect( wrapper.instance().getApiClient() ).toBeUndefined();
 		} );
 	} );
 
@@ -208,10 +208,10 @@ describe( 'ApiProvider', () => {
 				</ApiProvider>
 			);
 
-			api.dataRequested( '123', [ 'thing:1', 'thing:2' ] );
+			api.dataRequested( [ 'thing:1', 'thing:2' ] );
 			expect( dataReceived ).not.toHaveBeenCalled();
 			expect( dataRequested ).toHaveBeenCalledTimes( 1 );
-			expect( dataRequested ).toHaveBeenCalledWith( 'test-api', '123', [ 'thing:1', 'thing:2' ] );
+			expect( dataRequested ).toHaveBeenCalledWith( 'test-api', [ 'thing:1', 'thing:2' ] );
 		} );
 	} );
 
@@ -232,13 +232,13 @@ describe( 'ApiProvider', () => {
 				</ApiProvider>
 			);
 
-			api.dataReceived( '123', {
+			api.dataReceived( {
 				'thing:1': { data: { color: 'blue' } },
 				'thing:2': { error: { message: 'oops!' } },
 			} );
 			expect( dataRequested ).not.toHaveBeenCalled();
 			expect( dataReceived ).toHaveBeenCalledTimes( 1 );
-			expect( dataReceived ).toHaveBeenCalledWith( 'test-api', '123', {
+			expect( dataReceived ).toHaveBeenCalledWith( 'test-api', {
 				'thing:1': { data: { color: 'blue' } },
 				'thing:2': { error: { message: 'oops!' } },
 			} );

--- a/src/react-redux/__tests__/with-api-client.spec.js
+++ b/src/react-redux/__tests__/with-api-client.spec.js
@@ -17,7 +17,6 @@ describe( 'withApiClient', () => {
 	let Component;
 	let mapSelectorsToProps;
 	let mapMutationsToProps;
-	let getClientKey;
 	let getApiClient;
 
 	beforeEach( () => {
@@ -30,117 +29,84 @@ describe( 'withApiClient', () => {
 		};
 
 		mapSelectorsToProps = () => ( {} );
-		getClientKey = ( { clientKey } ) => clientKey;
 
-		getApiClient = ( clientKey ) => {
-			return api.getClient( clientKey );
+		getApiClient = () => {
+			return api.getClient();
 		};
 	} );
 
 	it( 'should render wrapped component.', () => {
-		const ComponentWithApiClient = withApiClient( 'test', { mapSelectorsToProps, getClientKey } )( Component );
-		const wrapper = mount( <ComponentWithApiClient clientKey="123" />, { context: { getApiClient } } );
+		const ComponentWithApiClient = withApiClient( 'test', { mapSelectorsToProps } )( Component );
+		const wrapper = mount( <ComponentWithApiClient />, { context: { getApiClient } } );
 		expect( wrapper.find( '.test-span' ) ).toHaveLength( 1 );
 	} );
 
 	it( 'should set displayName for wrapped component with displayName.', () => {
 		Component.displayName = 'TestDisplayName';
-		const ComponentWithApiClient = withApiClient( 'test', { mapSelectorsToProps, getClientKey } )( Component );
+		const ComponentWithApiClient = withApiClient( 'test', { mapSelectorsToProps } )( Component );
 		expect( ComponentWithApiClient.displayName ).toBe( 'ApiClientConnect( TestDisplayName )' );
 	} );
 
 	it( 'should set displayName for wrapped component without displayName.', () => {
 		Component.displayName = null;
-		const ComponentWithApiClient = withApiClient( 'test', { mapSelectorsToProps, getClientKey } )( Component );
+		const ComponentWithApiClient = withApiClient( 'test', { mapSelectorsToProps } )( Component );
 		expect( ComponentWithApiClient.displayName ).toBe( 'ApiClientConnect( ' + Component.name + ' )' );
 	} );
 
 	it( 'should render wrapped component even without getApiClient in context.', () => {
-		const ComponentWithApiClient = withApiClient( 'test', { mapSelectorsToProps, getClientKey } )( Component );
-		const wrapper = mount( <ComponentWithApiClient clientKey="123" /> );
+		const ComponentWithApiClient = withApiClient( 'test', { mapSelectorsToProps } )( Component );
+		const wrapper = mount( <ComponentWithApiClient /> );
 		expect( wrapper.find( '.test-span' ) ).toHaveLength( 1 );
 	} );
 
 	it( 'should return null if wrapped component is not valid.', () => {
-		const result = withApiClient( 'test', { mapSelectorsToProps, getClientKey } )( '' );
+		const result = withApiClient( 'test', { mapSelectorsToProps } )( '' );
 		expect( result ).toBeNull();
 	} );
 
 	describe( '#updateClient', () => {
-		it( 'should call getClientKey with given props.', () => {
-			getClientKey = jest.fn();
-			getClientKey.mockReturnValue( '123' );
-
-			const ComponentWithApiClient = withApiClient( 'test', { mapSelectorsToProps, getClientKey } )( Component );
-			mount( <ComponentWithApiClient clientKey="123" />, { context: { getApiClient } } );
-
-			expect( getClientKey ).toHaveBeenLastCalledWith( { clientKey: '123' } );
-		} );
-
 		it( 'should call getApiClient on mount.', () => {
 			const mockGetApiClient = jest.fn();
-			mockGetApiClient.mockReturnValue( getApiClient( '123' ) );
-			const ComponentWithApiClient = withApiClient( 'test', { mapSelectorsToProps, getClientKey } )( Component );
+			mockGetApiClient.mockReturnValue( getApiClient() );
+			const ComponentWithApiClient = withApiClient( 'test', { mapSelectorsToProps } )( Component );
 			mount(
-				<ComponentWithApiClient clientKey="123" />,
+				<ComponentWithApiClient />,
 				{ context: { getApiClient: mockGetApiClient } }
 			);
 
-			expect( mockGetApiClient ).toHaveBeenCalledTimes( 1 );
-			expect( mockGetApiClient ).toHaveBeenCalledWith( '123' );
+			expect( mockGetApiClient ).toHaveBeenCalled();
 		} );
 
-		it( 'should call getApiClient on update.', () => {
-			const mockGetApiClient = jest.fn();
-			mockGetApiClient.mockReturnValueOnce( getApiClient( '123' ) );
-			mockGetApiClient.mockReturnValueOnce( getApiClient( '456' ) );
-			const ComponentWithApiClient = withApiClient( 'test', { mapSelectorsToProps, getClientKey } )( Component );
-			const wrapper = mount(
-				<ComponentWithApiClient clientKey="123" />,
-				{ context: { getApiClient: mockGetApiClient } }
-			);
-
-			expect( mockGetApiClient ).toHaveBeenCalledTimes( 1 );
-			expect( mockGetApiClient ).toHaveBeenLastCalledWith( '123' );
-
-			wrapper.setProps( { clientKey: '456' } );
-
-			expect( mockGetApiClient ).toHaveBeenCalledTimes( 2 );
-			expect( mockGetApiClient ).toHaveBeenLastCalledWith( '456' );
-		} );
-
-		it( 'should set clientKey and client in state.', () => {
-			const ComponentWithApiClient = withApiClient( 'test', { mapSelectorsToProps, getClientKey } )( Component );
-			const wrapper = mount( <ComponentWithApiClient clientKey="123" />, { context: { getApiClient } } );
+		it( 'should set client in state.', () => {
+			const ComponentWithApiClient = withApiClient( 'test', { mapSelectorsToProps } )( Component );
+			const wrapper = mount( <ComponentWithApiClient />, { context: { getApiClient } } );
 
 			wrapper.instance().updateClient( {}, {} );
 
 			const state = wrapper.instance().state;
-			expect( state.clientKey ).toBe( '123' );
-			expect( state.client ).toBe( getApiClient( '123' ) );
+			expect( state.client ).toBe( getApiClient() );
 		} );
 
 		it( 'should subscribe to the ApiClient on mount.', () => {
-			const apiClient = getApiClient( '123' );
+			const apiClient = getApiClient();
 			apiClient.subscribe = jest.fn();
 
-			const ComponentWithApiClient = withApiClient( 'test', { mapSelectorsToProps, getClientKey } )( Component );
-			const wrapper = mount( <ComponentWithApiClient clientKey="123" />, { context: { getApiClient } } );
+			const ComponentWithApiClient = withApiClient( 'test', { mapSelectorsToProps } )( Component );
+			const wrapper = mount( <ComponentWithApiClient />, { context: { getApiClient } } );
 			const handleSubscriptionChange = wrapper.instance().handleSubscriptionChange;
 			const state = wrapper.instance().state;
 
 			expect( apiClient.subscribe ).toHaveBeenCalledTimes( 1 );
 			expect( apiClient.subscribe ).toHaveBeenCalledWith( handleSubscriptionChange );
-			expect( state.clientKey ).toBe( '123' );
 			expect( state.client ).toBe( apiClient );
 		} );
 
 		it( 'should unsubscribe from the ApiClient on unmount.', () => {
-			const apiClient = getApiClient( '123' );
+			const apiClient = getApiClient();
 			apiClient.unsubscribe = jest.fn();
 
-			const ComponentWithApiClient = withApiClient( 'test', { mapSelectorsToProps, getClientKey } )( Component );
-			const wrapper = mount( <ComponentWithApiClient clientKey="123" />, { context: { getApiClient } } );
+			const ComponentWithApiClient = withApiClient( 'test', { mapSelectorsToProps } )( Component );
+			const wrapper = mount( <ComponentWithApiClient />, { context: { getApiClient } } );
 
 			const handleSubscriptionChange = wrapper.instance().handleSubscriptionChange;
 			wrapper.unmount();
@@ -148,17 +114,41 @@ describe( 'withApiClient', () => {
 			expect( apiClient.unsubscribe ).toHaveBeenCalledTimes( 1 );
 			expect( apiClient.unsubscribe ).toHaveBeenCalledWith( handleSubscriptionChange );
 		} );
+
+		it( 'should unsubscribe from the ApiClient if a different api is set.', () => {
+			const api1 = new TestApi();
+			api1.getClient().unsubscribe = jest.fn();
+
+			const api2 = new TestApi();
+			api2.getClient().unsubscribe = jest.fn();
+
+			const getApiClient1 = jest.fn();
+			getApiClient1.mockReturnValue( api1.getClient() );
+
+			const getApiClient2 = jest.fn();
+			getApiClient2.mockReturnValue( api2.getClient() );
+
+			const ComponentWithApiClient = withApiClient( 'test', { mapSelectorsToProps } )( Component );
+			const wrapper = mount( <ComponentWithApiClient />, { context: { getApiClient: getApiClient1 } } );
+			const handleSubscriptionChange = wrapper.instance().handleSubscriptionChange;
+
+			wrapper.setContext( { getApiClient: getApiClient2 } );
+
+			expect( api1.getClient().unsubscribe ).toHaveBeenCalledTimes( 1 );
+			expect( api1.getClient().unsubscribe ).toHaveBeenCalledWith( handleSubscriptionChange );
+			expect( api2.getClient().unsubscribe ).not.toHaveBeenCalled();
+		} );
 	} );
 
 	describe( '#handleSubscriptionChange', () => {
 		it( 'should update when ApiClient state changes.', () => {
-			const apiClient = getApiClient( '123' );
+			const apiClient = getApiClient();
 
-			const ComponentWithApiClient = withApiClient( 'test', { mapSelectorsToProps, getClientKey } )( Component );
-			const wrapper = mount( <ComponentWithApiClient clientKey="123" />, { context: { getApiClient } } );
+			const ComponentWithApiClient = withApiClient( 'test', { mapSelectorsToProps } )( Component );
+			const wrapper = mount( <ComponentWithApiClient />, { context: { getApiClient } } );
 
 			const clientState = {
-				123: { resources: {}, },
+				resources: {},
 			};
 			apiClient.setState( clientState );
 
@@ -166,13 +156,13 @@ describe( 'withApiClient', () => {
 		} );
 
 		it( 'should not update when ApiClient state is identical.', () => {
-			const apiClient = getApiClient( '123' );
+			const apiClient = getApiClient();
 
-			const ComponentWithApiClient = withApiClient( 'test', { mapSelectorsToProps, getClientKey } )( Component );
-			const wrapper = mount( <ComponentWithApiClient clientKey="123" />, { context: { getApiClient } } );
+			const ComponentWithApiClient = withApiClient( 'test', { mapSelectorsToProps } )( Component );
+			const wrapper = mount( <ComponentWithApiClient />, { context: { getApiClient } } );
 
 			const clientState = {
-				123: { resources: {}, },
+				resources: {},
 			};
 			apiClient.setState( clientState );
 
@@ -181,42 +171,21 @@ describe( 'withApiClient', () => {
 
 			expect( wrapper.instance().setState ).not.toHaveBeenCalled();
 		} );
-
-		it( 'should not update when set with wrong ApiClient.', () => {
-			const apiClient1 = getApiClient( '123' );
-			const apiClient2 = getApiClient( '456' );
-
-			const ComponentWithApiClient = withApiClient( 'test', { mapSelectorsToProps, getClientKey } )( Component );
-			const wrapper = mount( <ComponentWithApiClient clientKey="123" />, { context: { getApiClient } } );
-			expect( wrapper.instance().state.clientState ).toBe( apiClient1.state );
-
-			apiClient1.unsubscribe = jest.fn(); // subvert the unsubscribe.
-			wrapper.setProps( { clientKey: '456' } );
-			expect( apiClient1.unsubscribe ).toHaveBeenCalled();
-			expect( wrapper.instance().state.clientState ).toBe( apiClient2.state );
-
-			const clientState = {
-				123: { resources: {}, },
-			};
-			apiClient1.setState( clientState );
-
-			expect( wrapper.instance().state.clientState ).toBe( apiClient2.state );
-		} );
 	} );
 
 	describe( '#mapSelectorsToProps', () => {
 		it( 'should call mapSelectorsToProps if present.', () => {
 			mapSelectorsToProps = jest.fn();
 
-			const ComponentWithApiClient = withApiClient( 'test', { mapSelectorsToProps, getClientKey } )( Component );
-			mount( <ComponentWithApiClient clientKey="123" />, { context: { getApiClient } } );
+			const ComponentWithApiClient = withApiClient( 'test', { mapSelectorsToProps } )( Component );
+			mount( <ComponentWithApiClient />, { context: { getApiClient } } );
 
 			expect( mapSelectorsToProps ).toHaveBeenCalledTimes( 1 );
 		} );
 
 		it( 'should provide api selectors to mapSelectorsToProps', () => {
 			const thing = { id: 1, color: 'red' };
-			let expectedProps = { clientKey: '123' };
+			let expectedProps = { testProp: 'testValue' };
 
 			mapSelectorsToProps = ( selectors, ownProps ) => {
 				const { getThing } = selectors;
@@ -233,18 +202,8 @@ describe( 'withApiClient', () => {
 				return <span className="test-span">Testing</span>;
 			};
 
-			const ComponentWithApiClient = withApiClient( 'test', { mapSelectorsToProps, getClientKey } )( Component );
-			mount( <ComponentWithApiClient clientKey="123" />, { context: { getApiClient } } );
-		} );
-
-		it( 'should render without mapSelectorsToProps', () => {
-			const ComponentWithApiClient = withApiClient( 'test', { getClientKey } )( Component );
-
-			const doRender = () => {
-				mount( <ComponentWithApiClient clientKey="123" />, { context: { getApiClient } } );
-			};
-
-			expect( doRender ).not.toThrow();
+			const ComponentWithApiClient = withApiClient( 'test', { mapSelectorsToProps } )( Component );
+			mount( <ComponentWithApiClient testProp="testValue" />, { context: { getApiClient } } );
 		} );
 	} );
 
@@ -252,8 +211,8 @@ describe( 'withApiClient', () => {
 		it( 'should call mapMutationsToProps if present.', () => {
 			mapMutationsToProps = jest.fn();
 
-			const ComponentWithApiClient = withApiClient( 'test', { mapMutationsToProps, getClientKey } )( Component );
-			mount( <ComponentWithApiClient clientKey="123" />, { context: { getApiClient } } );
+			const ComponentWithApiClient = withApiClient( 'test', { mapMutationsToProps } )( Component );
+			mount( <ComponentWithApiClient />, { context: { getApiClient } } );
 
 			expect( mapMutationsToProps ).toHaveBeenCalledTimes( 1 );
 		} );
@@ -265,8 +224,8 @@ describe( 'withApiClient', () => {
 
 			class MutationsTestApi extends FreshDataApi {
 				methods = {
-					put: ( clientKey ) => ( path, data ) => {
-						putFunc( clientKey, path, data );
+					put: ( path, data ) => {
+						putFunc( path, data );
 					},
 				}
 				operations = {
@@ -290,7 +249,7 @@ describe( 'withApiClient', () => {
 			}
 
 			api = new MutationsTestApi();
-			let expectedProps = { clientKey: '123' };
+			let expectedProps = { testProp: 'testValue' };
 			let mutationProps = null;
 
 			mapMutationsToProps = ( mutations, ownProps ) => {
@@ -308,8 +267,8 @@ describe( 'withApiClient', () => {
 				return <span className="test-span">Testing</span>;
 			};
 
-			const ComponentWithApiClient = withApiClient( 'test', { mapMutationsToProps, getClientKey } )( Component );
-			mount( <ComponentWithApiClient clientKey="123" />, { context: { getApiClient } } );
+			const ComponentWithApiClient = withApiClient( 'test', { mapMutationsToProps } )( Component );
+			mount( <ComponentWithApiClient testProp="testValue" />, { context: { getApiClient } } );
 
 			expect( updateFunc ).not.toHaveBeenCalled();
 
@@ -317,17 +276,17 @@ describe( 'withApiClient', () => {
 			expect( updateFunc ).toHaveBeenCalledTimes( 1 );
 			expect( updateFunc ).toHaveBeenCalledWith( 1, { id: 1, color: 'red' } );
 			expect( putFunc ).toHaveBeenCalledTimes( 1 );
-			expect( putFunc ).toHaveBeenCalledWith( '123', [ 'things', '1' ], { data: { id: 1, color: 'red' } } );
+			expect( putFunc ).toHaveBeenCalledWith( [ 'things', '1' ], { data: { id: 1, color: 'red' } } );
 		} );
+	} );
 
-		it( 'should render without mapMutationsToProps.', () => {
-			const ComponentWithApiClient = withApiClient( 'test', { getClientKey } )( Component );
+	it( 'should render without options.', () => {
+		const ComponentWithApiClient = withApiClient( 'test', {} )( Component );
 
-			const doRender = () => {
-				mount( <ComponentWithApiClient clientKey="123" />, { context: { getApiClient } } );
-			};
+		const doRender = () => {
+			mount( <ComponentWithApiClient />, { context: { getApiClient } } );
+		};
 
-			expect( doRender ).not.toThrow();
-		} );
+		expect( doRender ).not.toThrow();
 	} );
 } );

--- a/src/react-redux/actions.js
+++ b/src/react-redux/actions.js
@@ -3,21 +3,19 @@ import {
 	FRESH_DATA_REQUESTED,
 } from './action-types';
 
-export function dataRequested( apiName, clientKey, resourceNames, time = new Date() ) {
+export function dataRequested( apiName, resourceNames, time = new Date() ) {
 	return {
 		type: FRESH_DATA_REQUESTED,
 		apiName,
-		clientKey,
 		resourceNames,
 		time,
 	};
 }
 
-export function dataReceived( apiName, clientKey, resources, time = new Date() ) {
+export function dataReceived( apiName, resources, time = new Date() ) {
 	return {
 		type: FRESH_DATA_RECEIVED,
 		apiName,
-		clientKey,
 		resources,
 		time,
 	};

--- a/src/react-redux/provider.js
+++ b/src/react-redux/provider.js
@@ -70,27 +70,25 @@ export class ApiProvider extends Component {
 		}
 	}
 
-	getApiClient = ( clientKey ) => {
+	getApiClient = () => {
 		const { api } = this.props;
 		if ( ! api ) {
 			debug( 'No api prop set' );
 			return undefined;
 		}
-		return api.getClient( clientKey );
+		return api.getClient();
 	}
 
-	// TODO: Remove unused api param.
-	dataRequested = ( api, clientKey, resourceNames ) => {
+	dataRequested = ( resourceNames ) => {
 		const { apiName } = this.props;
 		const { dataRequested } = this.props;
-		dataRequested( apiName, clientKey, resourceNames );
+		dataRequested( apiName, resourceNames );
 	}
 
-	// TODO: Remove unused api param.
-	dataReceived = ( api, clientKey, resources ) => {
+	dataReceived = ( resources ) => {
 		const { apiName } = this.props;
 		const { dataReceived } = this.props;
-		dataReceived( apiName, clientKey, resources );
+		dataReceived( apiName, resources );
 	};
 
 	render() {

--- a/src/react-redux/reducer/__tests__/index.spec.js
+++ b/src/react-redux/reducer/__tests__/index.spec.js
@@ -18,17 +18,14 @@ describe( 'reducer', () => {
 	it( 'should pass down an apiclient state to the apiclient reducer', () => {
 		const state1 = {
 			testApi: {
-				123: {
-					resources: {
-						'thing:1': { lastRequested: now - 2000 },
-					},
+				resources: {
+					'thing:1': { lastRequested: now - 2000 },
 				},
 			},
 		};
 		const action = {
 			type: FRESH_DATA_RECEIVED,
 			apiName: 'testApi',
-			clientKey: '123',
 			resources: {
 				'thing:1': { lastReceived: now, data: { foot: 'red' } },
 				'thing:2': { lastReceived: now, data: { foot: 'blue' } },
@@ -46,10 +43,10 @@ describe( 'reducer', () => {
 		const state2 = reducer( state1, action, [ reducerMock ] );
 
 		expect( reducerMock ).toHaveBeenCalledTimes( 1 );
-		expect( reducerMock ).toHaveBeenCalledWith( state1.testApi[ 123 ], action );
-		expect( state2.testApi[ 123 ].resources[ 'thing:1' ].lastRequested ).toEqual( now - 2000 );
-		expect( state2.testApi[ 123 ].resources[ 'thing:1' ].lastReceived ).toEqual( now );
-		expect( state2.testApi[ 123 ].resources[ 'thing:2' ].lastReceived ).toEqual( now );
+		expect( reducerMock ).toHaveBeenCalledWith( state1.testApi, action );
+		expect( state2.testApi.resources[ 'thing:1' ].lastRequested ).toEqual( now - 2000 );
+		expect( state2.testApi.resources[ 'thing:1' ].lastReceived ).toEqual( now );
+		expect( state2.testApi.resources[ 'thing:2' ].lastReceived ).toEqual( now );
 	} );
 
 	it( 'should create a new sub state for the sub reducer', () => {
@@ -57,7 +54,6 @@ describe( 'reducer', () => {
 		const action = {
 			type: FRESH_DATA_RECEIVED,
 			apiName: 'testApi',
-			clientKey: '123',
 			resources: { 'thing:1': { lastRequested: now - 2000 } },
 			time: now,
 		};
@@ -68,7 +64,7 @@ describe( 'reducer', () => {
 		const state2 = reducer( state1, action, [ reducerMock ] );
 
 		expect( reducerMock ).toHaveBeenCalledTimes( 1 );
-		expect( reducerMock ).toHaveBeenCalledWith( undefined, action );
-		expect( state2.testApi[ 123 ].resources[ 'thing:1' ].lastRequested ).toEqual( now - 2000 );
+		expect( reducerMock ).toHaveBeenCalledWith( {}, action );
+		expect( state2.testApi.resources[ 'thing:1' ].lastRequested ).toEqual( now - 2000 );
 	} );
 } );

--- a/src/react-redux/reducer/index.js
+++ b/src/react-redux/reducer/index.js
@@ -8,16 +8,13 @@ const _subReducers = [
 ];
 
 export default function reducer( state = _defaultState, action, subReducers = _subReducers ) {
-	const { apiName, clientKey } = action;
+	const { apiName } = action;
 
-	if ( apiName && clientKey ) {
-		const apiState = state[ apiName ] || {};
+	if ( apiName ) {
+		const newApiState = subReducers.reduce( ( apiState, subReducer ) => {
+			return subReducer( apiState, action );
+		}, state[ apiName ] || {} );
 
-		const newClientState = subReducers.reduce( ( clientState, subReducer ) => {
-			return subReducer( clientState, action );
-		}, apiState[ clientKey ] );
-
-		const newApiState = { ...apiState, [ clientKey ]: newClientState };
 		const newState = { ...state, [ apiName ]: newApiState };
 		return newState;
 	}

--- a/src/react-redux/with-api-client.js
+++ b/src/react-redux/with-api-client.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 const debug = debugFactory( 'fresh-data:with-api-client' );
 
 export default function withApiClient( apiName, options ) {
-	const { getClientKey, mapSelectorsToProps, mapMutationsToProps } = options;
+	const { mapSelectorsToProps, mapMutationsToProps } = options;
 
 	return function connectWithApiClient( WrappedComponent ) {
 		if ( typeof WrappedComponent !== 'function' ) {
@@ -28,7 +28,7 @@ export default function withApiClient( apiName, options ) {
 			static childContextTypes = WrappedComponent.childContextTypes;
 			static WrappedComponent = WrappedComponent;
 
-			state = { clientKey: null, client: null, clientState: null };
+			state = { client: null, clientState: null };
 
 			componentDidMount() {
 				this.updateClient( this.props, this.state );
@@ -49,23 +49,22 @@ export default function withApiClient( apiName, options ) {
 			}
 
 			updateClient = ( nextProps, prevState ) => {
-				const clientKey = getClientKey( nextProps );
-				if ( clientKey !== prevState.clientKey ) {
-					const { getApiClient } = this.context;
+				const { getApiClient } = this.context;
 
-					if ( ! getApiClient ) {
-						debug(
-							'getApiClient not found in context. ' +
-							'Ensure this component is a child of the FreshDataProvider component.'
-						);
-						return;
-					}
+				if ( ! getApiClient ) {
+					debug(
+						'getApiClient not found in context. ' +
+						'Ensure this component is a child of the ApiProvider component.'
+					);
+					return;
+				}
 
-					const client = getApiClient( clientKey );
+				const client = getApiClient();
+				if ( client !== prevState.client ) {
 					const clientState = client.state;
 					client.subscribe( this.handleSubscriptionChange );
 					this.setState( () => {
-						return { clientKey, client, clientState };
+						return { client, clientState };
 					} );
 				}
 			}


### PR DESCRIPTION
This removes clientKey altogether from the api and associated code. The
clientKey can be directly associated with an instance of the API, we
don't need to keep multiple clients for the same instance. We can just
create multiple instances of the same API.

To Test:
1. `npm install`, `npm test` and ensure all tests pass.

For further cumulative testing of this and associated PRs, visit #81 