### PR TITLE
Remove methods from apiSpec.

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -15,14 +15,13 @@ function _clearTimer( id ) {
 
 export default class ApiClient {
 	constructor( apiSpec, setTimer = _setTimer, clearTimer = _clearTimer ) {
-		const { methods, operations, mutations, selectors } = apiSpec;
+		const { operations, mutations, selectors } = apiSpec;
 		const readOperationName = apiSpec.readOperationName || DEFAULT_READ_OPERATION;
 
 		this.uid = uniqueId();
 		this.debug = debugFactory( `fresh-data:api-client[${ this.uid }]` );
 		this.debug( 'New ApiClient for apiSpec: ', apiSpec );
 
-		this.methods = methods;
 		this.operations = operations && this.mapOperations( operations );
 		this.mutations = mutations && mapFunctions( mutations, this.operations );
 		this.selectors = selectors;
@@ -182,7 +181,7 @@ export default class ApiClient {
 		try {
 			this.dataRequested( resourceNames );
 
-			const operationResult = apiOperation( this.methods )( resourceNames, data ) || [];
+			const operationResult = apiOperation( resourceNames, data ) || [];
 			const values = isArray( operationResult ) ? operationResult : [ operationResult ];
 
 			const requests = values.map( async ( value ) => {

--- a/src/react-redux/__tests__/with-api-client.spec.js
+++ b/src/react-redux/__tests__/with-api-client.spec.js
@@ -212,18 +212,13 @@ describe( 'withApiClient', () => {
 			const updateFunc = jest.fn();
 
 			apiSpec = {
-				methods: {
-					put: ( path, data ) => {
-						putFunc( path, data );
-					},
-				},
 				operations: {
-					update: ( { put } ) => ( resourceNames, resourceData ) => {
+					update: ( resourceNames, resourceData ) => {
 						const filteredNames = resourceNames.filter( name => startsWith( name, 'thing:' ) );
 						return filteredNames.reduce( ( requests, name ) => {
 							const id = name.substr( name.indexOf( ':' ) + 1 );
 							const data = resourceData[ name ];
-							requests[ name ] = put( [ 'things', id ], { data } );
+							requests[ name ] = putFunc( [ 'things', id ], { data } );
 							return requests;
 						}, {} );
 					},


### PR DESCRIPTION
This removes the methods because the operations can be pre-loaded with
them when the apiSpec is created.

To Test:
1. `npm install`, `npm test` and ensure all tests pass.

Further testing can be done via PR #81 