### PR TITLE
Fix package.json test script and lerna link

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,10 @@
 	"scripts": {
 		"clean": "lerna run clean",
 		"bootstrap": "lerna bootstrap --hoist",
+		"linkLocal": "lerna link --force-local",
 		"lint": "eslint ./packages",
 		"test": "jest --runInBand",
-		"test:watch": "npm run test:watch",
+		"test:watch": "jest --runInBand --watchAll",
 		"coverage": "codecov",
 		"build": "lerna run build",
 		"prepublishOnly": "npm run clean && npm run lint && npm run build && npm test"


### PR DESCRIPTION
This adds a `linkLocal` script that can be used to link local packages
together without trying to hoist packages, which can be problematic for
example code that relies on `react-scripts` for binary access (which
hoisting thwarts)

It also fixes a previous `test:watch` script where `lerna` got
accidentally switched to `npm` which caused this script to not work.