### PR TITLE
Add methods for component requirements

### DIFF
--- a/examples/github-api/src/UserInfo.js
+++ b/examples/github-api/src/UserInfo.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { MINUTE, withApiClient } from '@fresh-data/react-provider';
+import { MINUTE } from '@fresh-data/framework';
+import { withApiClient } from '@fresh-data/react-provider';
 import UserStars from './UserStars';
 
 function renderLoading( userName ) {

--- a/examples/github-api/src/UserStars.js
+++ b/examples/github-api/src/UserStars.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { MINUTE, withApiClient } from '@fresh-data/react-provider';
+import { MINUTE } from '@fresh-data/framework';
+import { withApiClient } from '@fresh-data/react-provider';
 
 function renderStarLi( repo ) {
 	return (

--- a/packages/framework/src/client/index.js
+++ b/packages/framework/src/client/index.js
@@ -96,17 +96,33 @@ export default class ApiClient {
 		return this.mutations;
 	}
 
+	getSelectors = ( componentRequirements ) => {
+		return mapFunctions( this.selectors, this.getResource, this.requireResource( componentRequirements ) );
+	}
+
+	clearComponentRequirements = ( component, now = new Date() ) => {
+		this.requirementsByComponent.clear( component );
+		this.updateRequirementsByResource( now );
+	}
+
+	setComponentRequirements = ( component, componentRequirements, now = new Date() ) => {
+		this.requirementsByComponent.set( component, componentRequirements );
+		this.updateRequirementsByResource( now );
+	}
+
 	setComponentData = ( component, selectorFunc, now = new Date() ) => {
 		if ( selectorFunc ) {
 			const componentRequirements = [];
-			const selectors = mapFunctions( this.selectors, this.getResource, this.requireResource( componentRequirements ) );
+			const selectors = this.getSelectors( componentRequirements );
 			selectorFunc( selectors );
 
-			this.requirementsByComponent.set( component, componentRequirements );
+			this.setComponentRequirements( component, componentRequirements, now );
 		} else {
-			this.requirementsByComponent.clear( component );
+			this.clearComponentRequirements( component, now );
 		}
+	}
 
+	updateRequirementsByResource = ( now = new Date() ) => {
 		// TODO: Consider using a reducer style function for resource requirements so we don't
 		// have to do a deep equals check.
 		const requirementsByResource = combineComponentRequirements( this.requirementsByComponent );
@@ -114,7 +130,7 @@ export default class ApiClient {
 			this.requirementsByResource = requirementsByResource;
 			this.updateTimer( now );
 		}
-	};
+	}
 
 	updateRequirementsData = async ( now ) => {
 		const { requirementsByComponent, requirementsByResource, state, minUpdate, maxUpdate } = this;


### PR DESCRIPTION
This adds piecemeal methods for getting, setting, and clearing component
requirements instead of this only being done via a callback approach as
is used in `setComponentData`. This makes the client more compatible
with other systems that cannot provide callback support in this way.