### PR TITLE
client: Fix the clearing of component requiremens.

### DIFF
--- a/packages/framework/src/client/__tests__/index.spec.js
+++ b/packages/framework/src/client/__tests__/index.spec.js
@@ -147,6 +147,87 @@ describe( 'ApiClient', () => {
 		} );
 	} );
 
+	describe( '#setComponentRequirements', () => {
+		const apiSpec = {
+			selectors: thingSelectors,
+		};
+
+		const component = () => {};
+		const requirements = [];
+		let apiClient = null;
+
+		beforeEach( () => {
+			apiClient = new ApiClient( apiSpec );
+		} );
+
+		afterEach( () => {
+			apiClient.clearComponentRequirements( component );
+		} );
+
+		it( 'sets component requirements when none were set before', () => {
+			expect( apiClient.requirementsByComponent.get( component ) ).toBe( undefined );
+			apiClient.setComponentRequirements( component, requirements );
+			expect( apiClient.requirementsByComponent.get( component ) ).toBe( requirements );
+		} );
+
+		it( 'sets component requirements when some were set before', () => {
+			const requirements2 = [];
+
+			apiClient.setComponentRequirements( component, requirements );
+			expect( apiClient.requirementsByComponent.get( component ) ).toBe( requirements );
+
+			apiClient.setComponentRequirements( component, requirements2 );
+			expect( apiClient.requirementsByComponent.get( component ) ).not.toBe( requirements );
+			expect( apiClient.requirementsByComponent.get( component ) ).toBe( requirements2 );
+		} );
+
+		it( 'sets multiple component requirements', () => {
+			const component2 = () => {};
+			const requirements2 = [];
+
+			apiClient.setComponentRequirements( component, requirements );
+			apiClient.setComponentRequirements( component2, requirements2 );
+			expect( apiClient.requirementsByComponent.get( component ) ).toBe( requirements );
+			expect( apiClient.requirementsByComponent.get( component2 ) ).toBe( requirements2 );
+		} );
+	} );
+
+	describe( '#clearComponentRequirements', () => {
+		const apiSpec = {
+			selectors: thingSelectors,
+		};
+
+		const component = () => {};
+		const requirements = [];
+		let apiClient = null;
+
+		beforeEach( () => {
+			apiClient = new ApiClient( apiSpec );
+		} );
+
+		it( 'clears component requirements', () => {
+			apiClient.setComponentRequirements( component, requirements );
+			expect( apiClient.requirementsByComponent.get( component ) ).toBe( requirements );
+
+			apiClient.clearComponentRequirements( component );
+			expect( apiClient.requirementsByComponent.get( component ) ).toBe( undefined );
+		} );
+
+		it( 'clears only the component given', () => {
+			const component2 = () => {};
+			const requirements2 = [];
+
+			apiClient.setComponentRequirements( component, requirements );
+			apiClient.setComponentRequirements( component2, requirements2 );
+			expect( apiClient.requirementsByComponent.get( component ) ).toBe( requirements );
+			expect( apiClient.requirementsByComponent.get( component2 ) ).toBe( requirements2 );
+
+			apiClient.clearComponentRequirements( component );
+			expect( apiClient.requirementsByComponent.get( component ) ).toBe( undefined );
+			expect( apiClient.requirementsByComponent.get( component2 ) ).toBe( requirements2 );
+		} );
+	} );
+
 	describe( '#setComponentData', () => {
 		const apiSpec = {
 			selectors: thingSelectors,

--- a/packages/framework/src/client/index.js
+++ b/packages/framework/src/client/index.js
@@ -101,7 +101,7 @@ export default class ApiClient {
 	}
 
 	clearComponentRequirements = ( component, now = new Date() ) => {
-		this.requirementsByComponent.clear( component );
+		this.requirementsByComponent.delete( component );
 		this.updateRequirementsByResource( now );
 	}
 


### PR DESCRIPTION
The ApiClient code was using Map.clear() instead of Map.delete() which
was deleting all entries from the Map instead of just the one desired.
Tests were added to exhibit this behavior and to verify the fix.

To Test:
1. `npm install`
2. `npm run bootstrap`
3. `npm test` and ensure all tests run successfully.