### PR TITLE
Add devinfo to example apps

### DIFF
--- a/examples/github-api/package-lock.json
+++ b/examples/github-api/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "example_github-api",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -888,22 +888,6 @@
         "regenerator-runtime": "^0.12.0"
       }
     },
-    "@babel/runtime-corejs2": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.4.2.tgz",
-      "integrity": "sha512-y/Br/9uQnumcqcakkmobFqOTzYCWSS6Kuy1b2o7LTXR4lpeU0AhaOcPqIHW85LCxRWUDW5Vg0pU1KlE3YkORlg==",
-      "requires": {
-        "core-js": "^2.6.5",
-        "regenerator-runtime": "^0.13.2"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.13.2",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
-          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
-        }
-      }
-    },
     "@babel/template": {
       "version": "7.2.2",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.2.2.tgz",
@@ -950,17 +934,32 @@
       "dev": true
     },
     "@fresh-data/framework": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@fresh-data/framework/-/framework-0.5.1.tgz",
-      "integrity": "sha512-pCrY2AYZgsGo4/smCNQM2NHf37yPMuzg4RCXHJAnOHIpo6eMgz1jlvlCN4JLxrcdoeEq3uIWMD/3F3k/MefLJQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@fresh-data/framework/-/framework-0.6.0.tgz",
+      "integrity": "sha512-6cVi0RHwgpbS3u0fEM9nMz8bYb2cL83REAL7jgHR2+zY0hcpynm+JiXZnOXt0f+4Caq3JavOAIlYiZsqlAzkTg==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.1.5"
+        "@babel/runtime": "^7.4.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.4.3",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.3.tgz",
+          "integrity": "sha512-9lsJwJLxDh/T3Q3SZszfWOTkk3pHbkmH+3KY+zwIDmsNlxsumuhS2TH3NIpktU4kNvfzy+k3eLT7aTJSPTo0OA==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+        }
       }
     },
     "@fresh-data/react-provider": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@fresh-data/react-provider/-/react-provider-0.5.1.tgz",
-      "integrity": "sha512-qolfBhPAkTB7WObh8VIsrfybMwJXYjnjhyefh613aZf8fA8Q0y7rnWJJgUhGMiKqtWVrZj0JhrjNTxA+MLN+dg==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@fresh-data/react-provider/-/react-provider-0.6.0.tgz",
+      "integrity": "sha512-EHU7dbvAWPhPOI8b6stzFMNaZdZoE/UVBtowtfXJAak/7k1neS3H9mTryWiha62NpoxSRT0LUIf0tVhG+BiAtw==",
       "requires": {
         "@babel/runtime": "^7.1.2",
         "prop-types": "^15.6.2"
@@ -4166,7 +4165,8 @@
     "core-js": {
       "version": "2.6.5",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
-      "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A=="
+      "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",

--- a/examples/github-api/src/api-spec/github-rest-api.js
+++ b/examples/github-api/src/api-spec/github-rest-api.js
@@ -5,6 +5,7 @@ const BASE_URL = 'https://api.github.com/';
 
 export function createApiSpec( fetch = window.fetch ) {
 	return {
+		name: 'github',
 		operations: {
 			read( resourceNames ) {
 				return [

--- a/examples/github-api/src/index.js
+++ b/examples/github-api/src/index.js
@@ -5,6 +5,10 @@ import App from './App';
 import createStore from './create-store';
 import reducer from './reducer';
 
+if ( 'development' === process.env.NODE_ENV ) {
+	window.__FRESH_DATA_DEV_INFO__ = true;
+}
+
 const store = createStore( reducer );
 
 ReactDOM.render( <App store={ store } />, document.getElementById( 'root' ) );

--- a/examples/hello-world/package-lock.json
+++ b/examples/hello-world/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "example_hello-world",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -888,22 +888,6 @@
         "regenerator-runtime": "^0.12.0"
       }
     },
-    "@babel/runtime-corejs2": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.4.2.tgz",
-      "integrity": "sha512-y/Br/9uQnumcqcakkmobFqOTzYCWSS6Kuy1b2o7LTXR4lpeU0AhaOcPqIHW85LCxRWUDW5Vg0pU1KlE3YkORlg==",
-      "requires": {
-        "core-js": "^2.6.5",
-        "regenerator-runtime": "^0.13.2"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.13.2",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
-          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
-        }
-      }
-    },
     "@babel/template": {
       "version": "7.2.2",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.2.2.tgz",
@@ -950,17 +934,32 @@
       "dev": true
     },
     "@fresh-data/framework": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@fresh-data/framework/-/framework-0.5.1.tgz",
-      "integrity": "sha512-pCrY2AYZgsGo4/smCNQM2NHf37yPMuzg4RCXHJAnOHIpo6eMgz1jlvlCN4JLxrcdoeEq3uIWMD/3F3k/MefLJQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@fresh-data/framework/-/framework-0.6.0.tgz",
+      "integrity": "sha512-6cVi0RHwgpbS3u0fEM9nMz8bYb2cL83REAL7jgHR2+zY0hcpynm+JiXZnOXt0f+4Caq3JavOAIlYiZsqlAzkTg==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.1.5"
+        "@babel/runtime": "^7.4.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.4.3",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.3.tgz",
+          "integrity": "sha512-9lsJwJLxDh/T3Q3SZszfWOTkk3pHbkmH+3KY+zwIDmsNlxsumuhS2TH3NIpktU4kNvfzy+k3eLT7aTJSPTo0OA==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+        }
       }
     },
     "@fresh-data/react-provider": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@fresh-data/react-provider/-/react-provider-0.5.1.tgz",
-      "integrity": "sha512-qolfBhPAkTB7WObh8VIsrfybMwJXYjnjhyefh613aZf8fA8Q0y7rnWJJgUhGMiKqtWVrZj0JhrjNTxA+MLN+dg==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@fresh-data/react-provider/-/react-provider-0.6.0.tgz",
+      "integrity": "sha512-EHU7dbvAWPhPOI8b6stzFMNaZdZoE/UVBtowtfXJAak/7k1neS3H9mTryWiha62NpoxSRT0LUIf0tVhG+BiAtw==",
       "requires": {
         "@babel/runtime": "^7.1.2",
         "prop-types": "^15.6.2"
@@ -4166,7 +4165,8 @@
     "core-js": {
       "version": "2.6.5",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
-      "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A=="
+      "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",

--- a/examples/hello-world/src/index.js
+++ b/examples/hello-world/src/index.js
@@ -5,6 +5,10 @@ import App from './App';
 import createStore from './create-store';
 import reducer from './reducer';
 
+if ( 'development' === process.env.NODE_ENV ) {
+	window.__FRESH_DATA_DEV_INFO__ = true;
+}
+
 const store = createStore( reducer );
 
 render( <App store={ store } />, document.getElementById( 'root' ) );

--- a/examples/hello-world/src/test-api.js
+++ b/examples/hello-world/src/test-api.js
@@ -41,6 +41,7 @@ export function fetchGreetings() {
 }
 
 export default {
+	name: 'helloWorld',
 	operations: {
 		read: ( resourceNames ) => {
 			const requests = [];

--- a/examples/wp-rest-api/package-lock.json
+++ b/examples/wp-rest-api/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "example_wp-rest-api",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -888,22 +888,6 @@
         "regenerator-runtime": "^0.12.0"
       }
     },
-    "@babel/runtime-corejs2": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.4.2.tgz",
-      "integrity": "sha512-y/Br/9uQnumcqcakkmobFqOTzYCWSS6Kuy1b2o7LTXR4lpeU0AhaOcPqIHW85LCxRWUDW5Vg0pU1KlE3YkORlg==",
-      "requires": {
-        "core-js": "^2.6.5",
-        "regenerator-runtime": "^0.13.2"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.13.2",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
-          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
-        }
-      }
-    },
     "@babel/template": {
       "version": "7.2.2",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.2.2.tgz",
@@ -950,17 +934,32 @@
       "dev": true
     },
     "@fresh-data/framework": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@fresh-data/framework/-/framework-0.5.1.tgz",
-      "integrity": "sha512-pCrY2AYZgsGo4/smCNQM2NHf37yPMuzg4RCXHJAnOHIpo6eMgz1jlvlCN4JLxrcdoeEq3uIWMD/3F3k/MefLJQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@fresh-data/framework/-/framework-0.6.0.tgz",
+      "integrity": "sha512-6cVi0RHwgpbS3u0fEM9nMz8bYb2cL83REAL7jgHR2+zY0hcpynm+JiXZnOXt0f+4Caq3JavOAIlYiZsqlAzkTg==",
       "requires": {
-        "@babel/runtime-corejs2": "^7.1.5"
+        "@babel/runtime": "^7.4.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.4.3",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.3.tgz",
+          "integrity": "sha512-9lsJwJLxDh/T3Q3SZszfWOTkk3pHbkmH+3KY+zwIDmsNlxsumuhS2TH3NIpktU4kNvfzy+k3eLT7aTJSPTo0OA==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+        }
       }
     },
     "@fresh-data/react-provider": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@fresh-data/react-provider/-/react-provider-0.5.1.tgz",
-      "integrity": "sha512-qolfBhPAkTB7WObh8VIsrfybMwJXYjnjhyefh613aZf8fA8Q0y7rnWJJgUhGMiKqtWVrZj0JhrjNTxA+MLN+dg==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@fresh-data/react-provider/-/react-provider-0.6.0.tgz",
+      "integrity": "sha512-EHU7dbvAWPhPOI8b6stzFMNaZdZoE/UVBtowtfXJAak/7k1neS3H9mTryWiha62NpoxSRT0LUIf0tVhG+BiAtw==",
       "requires": {
         "@babel/runtime": "^7.1.2",
         "prop-types": "^15.6.2"
@@ -4172,7 +4171,8 @@
     "core-js": {
       "version": "2.6.5",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
-      "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A=="
+      "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",

--- a/examples/wp-rest-api/src/index.js
+++ b/examples/wp-rest-api/src/index.js
@@ -5,6 +5,10 @@ import App from './App';
 import createStore from './create-store';
 import reducer from './reducer';
 
+if ( 'development' === process.env.NODE_ENV ) {
+	window.__FRESH_DATA_DEV_INFO__ = true;
+}
+
 const store = createStore( reducer );
 
 render( <App store={ store } />, document.getElementById( 'root' ) );

--- a/examples/wp-rest-api/src/test-wp-rest-api.js
+++ b/examples/wp-rest-api/src/test-wp-rest-api.js
@@ -9,6 +9,7 @@ export function createApiSpec( siteUrl, methods = httpMethods ) {
 	const { get } = methods( baseUrl );
 
 	return {
+		name: 'wpRestApi',
 		operations: {
 			read: ( resourceNames ) => {
 				return readPostPages( get, resourceNames );

--- a/packages/framework/package-lock.json
+++ b/packages/framework/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fresh-data/framework",
-	"version": "0.5.1",
+	"version": "0.6.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/react-provider/package-lock.json
+++ b/packages/react-provider/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fresh-data/react-provider",
-	"version": "0.5.1",
+	"version": "0.6.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {


### PR DESCRIPTION
This adds devinfo and names to the example app api specs

To Test:

1. `npm install`, `npm run bootstrap`
2. For each example dir: `npm install`, `npm start`, ensure app runs, check dev console for `freshData.xxx` dev info in JS console.