### PR TITLE
Render-based refactor: Step 3

### DIFF
--- a/packages/framework/package-lock.json
+++ b/packages/framework/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fresh-data/framework",
-	"version": "0.6.0",
+	"version": "0.6.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/framework/src/client/__tests__/index.spec.js
+++ b/packages/framework/src/client/__tests__/index.spec.js
@@ -48,6 +48,27 @@ describe( 'ApiClient', () => {
 		expect( apiClient.state ).toBe( clientState );
 	} );
 
+	it( 'should make a default read operation that throws', () => {
+		const apiClient = new ApiClient( emptyApiSpec );
+
+		const callRead = () => apiClient.scheduler.fetch( [ 'a', 'b' ] );
+
+		expect( callRead ).toThrow();
+	} );
+
+	it( 'should set a read operation', () => {
+		const read = jest.fn();
+		const apiSpec = {
+			operations: { read },
+		};
+		const apiClient = new ApiClient( apiSpec );
+
+		apiClient.scheduler.fetch( [ 'a', 'b' ], 'data' );
+
+		expect( read ).toHaveBeenCalledWith( [ 'a', 'b' ], 'data' );
+	} );
+
+	/*
 	it( 'should update timer on set state', () => {
 		const clientState = { resources: {} };
 		const apiClient = new ApiClient( emptyApiSpec );
@@ -55,7 +76,9 @@ describe( 'ApiClient', () => {
 		apiClient.setState( clientState );
 		expect( apiClient.updateTimer ).toHaveBeenCalledTimes( 1 );
 	} );
+	*/
 
+	/*
 	it( 'should not set state twice', () => {
 		const clientState = { resources: {} };
 		const apiClient = new ApiClient( emptyApiSpec );
@@ -67,6 +90,7 @@ describe( 'ApiClient', () => {
 		apiClient.setState( clientState );
 		expect( apiClient.updateTimer ).not.toHaveBeenCalled();
 	} );
+	*/
 
 	it( 'should map mutations to operations', () => {
 		const createThing = jest.fn();
@@ -97,10 +121,12 @@ describe( 'ApiClient', () => {
 		expect( dataThing1 ).toBe( thing1 );
 	} );
 
+	/*
 	it( 'should start with no timeoutId', () => {
 		const apiClient = new ApiClient( emptyApiSpec );
 		expect( apiClient.timeoutId ).toBeNull();
 	} );
+	*/
 
 	describe( '#getResource', () => {
 		it( 'should return an empty object if the resource does not yet exist.', () => {
@@ -147,6 +173,7 @@ describe( 'ApiClient', () => {
 		} );
 	} );
 
+	/*
 	describe( '#setComponentRequirements', () => {
 		const apiSpec = {
 			selectors: thingSelectors,
@@ -191,7 +218,9 @@ describe( 'ApiClient', () => {
 			expect( apiClient.requirementsByComponent.get( component2 ) ).toBe( requirements2 );
 		} );
 	} );
+	*/
 
+	/*
 	describe( '#clearComponentRequirements', () => {
 		const apiSpec = {
 			selectors: thingSelectors,
@@ -227,7 +256,9 @@ describe( 'ApiClient', () => {
 			expect( apiClient.requirementsByComponent.get( component2 ) ).toBe( requirements2 );
 		} );
 	} );
+	*/
 
+	/*
 	describe( '#setComponentData', () => {
 		const apiSpec = {
 			selectors: thingSelectors,
@@ -306,7 +337,9 @@ describe( 'ApiClient', () => {
 			expect( apiClient.updateTimer ).not.toHaveBeenCalled();
 		} );
 	} );
+	*/
 
+	/*
 	describe( '#updateTimer', () => {
 		it( 'should accept and use nextUpdate when given.', () => {
 			const setTimer = jest.fn();
@@ -358,7 +391,9 @@ describe( 'ApiClient', () => {
 			expect( clearTimer ).not.toHaveBeenCalled();
 		} );
 	} );
+	*/
 
+	/*
 	describe( '#updateRequirementsData', () => {
 		const component = () => {};
 		let apiSpec;
@@ -510,6 +545,7 @@ describe( 'ApiClient', () => {
 			expect( apiClient.clearTimer ).not.toHaveBeenCalled();
 		} );
 	} );
+	*/
 
 	describe( '#applyOperation', () => {
 		let apiSpec;

--- a/packages/framework/src/client/__tests__/scheduler.spec.js
+++ b/packages/framework/src/client/__tests__/scheduler.spec.js
@@ -1,0 +1,338 @@
+import { isEmpty } from 'lodash';
+import Scheduler from '../scheduler';
+import { STATUS } from '../resource-request';
+import { MINUTE, SECOND } from '../../utils/constants';
+
+// TODO: Handle timeouts
+
+describe( 'Scheduler', () => {
+	const now = new Date();
+	const threeMinutesAgo = new Date( now.getTime() - ( 3 * MINUTE ) );
+	const fourMinutesAgo = new Date( now.getTime() - ( 4 * MINUTE ) );
+
+	describe( 'constructor', () => {
+		it( 'creates an array of requests', () => {
+			const scheduler = new Scheduler( () => {}, 0 );
+
+			expect( scheduler.requests ).toEqual( [] );
+		} );
+	} );
+
+	describe( 'scheduleRequest', () => {
+		it( 'creates an overdue request when no existing state exists', () => {
+			const scheduler = new Scheduler( () => {}, 0 );
+			const resourceName = 'resource1';
+
+			scheduler.scheduleRequest( resourceName, {}, {}, threeMinutesAgo );
+			const request = scheduler.requests[ 0 ];
+
+			expect( request ).not.toBe( undefined );
+			expect( request.getStatus( now ) ).toBe( STATUS.overdue );
+		} );
+
+		it( 'creates a scheduled request when state exists', () => {
+			const scheduler = new Scheduler( () => {}, 0 );
+			const resourceName = 'resource1';
+			const requirement = { freshness: 5 * MINUTE };
+			const resourceState = { lastReceived: threeMinutesAgo };
+
+			scheduler.scheduleRequest( resourceName, requirement, resourceState );
+			const request = scheduler.requests[ 0 ];
+
+			expect( request ).not.toBe( undefined );
+			expect( request.getStatus( now ) ).toBe( STATUS.scheduled );
+			expect( request.getTimeLeft( now ) ).toBe( 2 * MINUTE );
+		} );
+
+		it( 'updates an existing scheduled request with a new scheduled requirement', () => {
+			const scheduler = new Scheduler( () => {}, 0 );
+			const resourceName = 'resource1';
+			const requirement1 = { freshness: 5 * MINUTE };
+			const requirement2 = { freshness: 4 * MINUTE };
+			const requirement3 = { freshness: 2 * MINUTE };
+			const resourceState = { lastReceived: threeMinutesAgo };
+
+			scheduler.scheduleRequest( resourceName, requirement1, resourceState, now );
+			expect( scheduler.requests[ 0 ].getStatus( now ) ).toBe( STATUS.scheduled );
+			expect( scheduler.requests[ 0 ].getTimeLeft( now ) ).toBe( 2 * MINUTE );
+
+			scheduler.scheduleRequest( resourceName, requirement2, resourceState, now );
+			expect( scheduler.requests[ 0 ].getStatus( now ) ).toBe( STATUS.scheduled );
+			expect( scheduler.requests[ 0 ].getTimeLeft( now ) ).toBe( 1 * MINUTE );
+
+			scheduler.scheduleRequest( resourceName, requirement3, resourceState, now );
+			expect( scheduler.requests[ 0 ].getStatus( now ) ).toBe( STATUS.overdue );
+			expect( scheduler.requests[ 0 ].getTimeLeft( now ) ).toBe( -( 1 * MINUTE ) );
+		} );
+
+		it( 'does not add a new request when an identical previous request is already in flight', () => {
+			const scheduler = new Scheduler( () => {}, 0 );
+			const resourceName = 'resource1';
+			const requirement1 = { freshness: 5 * MINUTE };
+			const requirement2 = { freshness: 4 * MINUTE };
+			const resourceState = { lastReceived: threeMinutesAgo };
+
+			scheduler.scheduleRequest( resourceName, requirement1, resourceState, now );
+			expect( scheduler.requests.length ).toBe( 1 );
+			expect( scheduler.requests[ 0 ].getStatus( now ) ).toBe( STATUS.scheduled );
+			expect( scheduler.requests[ 0 ].getTimeLeft( now ) ).toBe( 2 * MINUTE );
+
+			scheduler.requests[ 0 ].getStatus = () => STATUS.inFlight;
+			scheduler.scheduleRequest( resourceName, requirement2, resourceState, now );
+
+			expect( scheduler.requests.length ).toBe( 1 );
+		} );
+	} );
+
+	describe( 'getScheduledRequest', () => {
+		it( 'finds a scheduled request', () => {
+			const scheduler = new Scheduler( () => {}, 0 );
+			const resourceName = 'resource1';
+			const requirement1 = { freshness: 5 * MINUTE };
+			const resourceState = { lastReceived: threeMinutesAgo };
+
+			scheduler.scheduleRequest( resourceName, requirement1, resourceState, now );
+			const request = scheduler.getScheduledRequest( resourceName );
+			expect( request.resourceName ).toBe( resourceName );
+			expect( request.getStatus() ).toBe( STATUS.scheduled );
+		} );
+	} );
+
+	describe( 'getInFlightRequests', () => {
+		it( 'finds any requests for a resource that are currently in-flight', () => {
+			const scheduler = new Scheduler( () => {}, 0 );
+			const resourceName = 'resource1';
+			const requirement1 = { freshness: 5 * MINUTE };
+			const resourceState = { lastReceived: threeMinutesAgo };
+
+			scheduler.scheduleRequest( resourceName, requirement1, resourceState, now );
+			scheduler.requests[ 0 ].getStatus = () => STATUS.inFlight;
+
+			const requests = scheduler.getInFlightRequests( resourceName );
+
+			expect( requests.length ).toBe( 1 );
+			expect( requests[ 0 ].resourceName ).toBe( resourceName );
+			expect( requests[ 0 ].getStatus() ).toBe( STATUS.inFlight );
+		} );
+	} );
+
+	describe( 'isRequestReady', () => {
+		it( 'returns false if the resource is still fresh enough', () => {
+			const scheduler = new Scheduler( () => {}, 0 );
+			const resourceName = 'resource1';
+			const requirement1 = { freshness: 5 * MINUTE };
+			const resourceState = { lastReceived: threeMinutesAgo };
+
+			scheduler.scheduleRequest( resourceName, requirement1, resourceState, now );
+			expect( scheduler.isRequestReady( scheduler.requests[ 0 ] ) ).toBeFalsy();
+		} );
+
+		it( 'returns true if the resource is not fresh enough', () => {
+			const scheduler = new Scheduler( () => {}, 0 );
+			const resourceName = 'resource1';
+			const requirement1 = { freshness: 2 * MINUTE };
+			const resourceState = { lastReceived: threeMinutesAgo };
+
+			scheduler.scheduleRequest( resourceName, requirement1, resourceState, now );
+			expect( scheduler.isRequestReady( scheduler.requests[ 0 ] ) ).toBeTruthy();
+		} );
+
+		it( 'returns true if the resource has not yet been fetched', () => {
+			const scheduler = new Scheduler( () => {}, 0 );
+			const resourceName = 'resource1';
+			const requirement1 = {};
+			const resourceState = {};
+
+			scheduler.scheduleRequest( resourceName, requirement1, resourceState, now );
+			expect( scheduler.isRequestReady( scheduler.requests[ 0 ] ) ).toBeTruthy();
+		} );
+
+		it( 'returns false if the resource status is anything but scheduled or overdue', () => {
+			const scheduler = new Scheduler( () => {}, 0 );
+			const resourceName = 'resource1';
+			const requirement1 = {};
+			const resourceState = {};
+
+			scheduler.scheduleRequest( resourceName, requirement1, resourceState, now );
+			const request = scheduler.requests[ 0 ];
+
+			request.getStatus = () => STATUS.complete;
+			expect( scheduler.isRequestReady( request ) ).toBeFalsy();
+
+			request.getStatus = () => STATUS.failed;
+			expect( scheduler.isRequestReady( request ) ).toBeFalsy();
+
+			request.getStatus = () => STATUS.inFlight;
+			expect( scheduler.isRequestReady( request ) ).toBeFalsy();
+
+			request.getStatus = () => STATUS.timedOut;
+			expect( scheduler.isRequestReady( request ) ).toBeFalsy();
+
+			request.getStatus = () => STATUS.unnecessary;
+			expect( scheduler.isRequestReady( request ) ).toBeFalsy();
+		} );
+	} );
+
+	describe( 'sendReadyRequests', () => {
+		it( 'does nothing when there are no requests in queue', () => {
+			const scheduler = new Scheduler( () => {}, 0 );
+
+			expect( isEmpty( scheduler.requests ) ).toBeTruthy();
+			scheduler.sendReadyRequests();
+			expect( isEmpty( scheduler.requests ) ).toBeTruthy();
+		} );
+
+		it( 'does nothing when there are no scheduled or overdue requests in queue', () => {
+			const scheduler = new Scheduler( () => {}, 0 );
+
+			scheduler.scheduleRequest( 'inFlightResource', {}, {}, now );
+			scheduler.requests[ 0 ].getStatus = () => STATUS.inFlight;
+
+			scheduler.scheduleRequest( 'timedOutResource', {}, {}, now );
+			scheduler.requests[ 1 ].getStatus = () => STATUS.timedOut;
+
+			scheduler.scheduleRequest( 'completeResource', {}, {}, now );
+			scheduler.requests[ 2 ].getStatus = () => STATUS.complete;
+
+			scheduler.scheduleRequest( 'failedResource', {}, {}, now );
+			scheduler.requests[ 3 ].getStatus = () => STATUS.failed;
+
+			scheduler.scheduleRequest( 'unnecessary', {}, {}, now );
+			scheduler.requests[ 4 ].getStatus = () => STATUS.unnecessary;
+
+			scheduler.sendReadyRequests( now );
+			expect( scheduler.requests.length ).toBe( 5 );
+		} );
+
+		it( 'Calls fetch with resource names', () => {
+			const fetch = jest.fn();
+			const scheduler = new Scheduler( fetch, 0 );
+
+			scheduler.scheduleRequest(
+				'resource1',
+				{ freshness: 5 * MINUTE },
+				{},
+				threeMinutesAgo
+			);
+			scheduler.scheduleRequest(
+				'resource2',
+				{ freshness: 3 * MINUTE },
+				{ lastReceived: fourMinutesAgo },
+				threeMinutesAgo
+			);
+
+			expect( scheduler.requests[ 0 ].getStatus( threeMinutesAgo ) ).toBe( STATUS.scheduled );
+			expect( scheduler.requests[ 1 ].getStatus( threeMinutesAgo ) ).toBe( STATUS.scheduled );
+
+			fetch.mockReturnValue( Promise.resolve() );
+
+			return scheduler.sendReadyRequests( now ).then( () => {
+				expect( fetch ).toHaveBeenCalledWith( [
+					scheduler.requests[ 0 ].resourceName,
+					scheduler.requests[ 1 ].resourceName
+				] );
+			} );
+		} );
+
+		it( 'calls request.requested for each ready request', () => {
+			const fetch = jest.fn();
+			const scheduler = new Scheduler( fetch, 0 );
+
+			scheduler.scheduleRequest(
+				'resource1',
+				{ freshness: 5 * MINUTE },
+				{},
+				threeMinutesAgo
+			);
+			scheduler.scheduleRequest(
+				'resource2',
+				{ freshness: 3 * MINUTE },
+				{ lastReceived: fourMinutesAgo },
+				threeMinutesAgo
+			);
+
+			expect( scheduler.requests[ 0 ].getStatus( threeMinutesAgo ) ).toBe( STATUS.scheduled );
+			expect( scheduler.requests[ 1 ].getStatus( threeMinutesAgo ) ).toBe( STATUS.scheduled );
+
+			const promise = Promise.resolve();
+			fetch.mockReturnValue( promise );
+
+			return scheduler.sendReadyRequests( now ).then( () => {
+				expect( scheduler.requests[ 0 ].getStatus( now ) ).toBe( STATUS.complete );
+				expect( scheduler.requests[ 1 ].getStatus( now ) ).toBe( STATUS.complete );
+			} );
+		} );
+	} );
+
+	describe( 'cleanUp', () => {
+		it( 'clears out completed and failed requests', () => {
+			const scheduler = new Scheduler( () => {}, 0 );
+
+			scheduler.scheduleRequest( 'scheduledResource', {}, {}, now );
+			scheduler.requests[ 0 ].getStatus = () => STATUS.scheduled;
+
+			scheduler.scheduleRequest( 'completeResource', {}, {}, now );
+			scheduler.requests[ 1 ].getStatus = () => STATUS.complete;
+
+			scheduler.scheduleRequest( 'failedResource', {}, {}, now );
+			scheduler.requests[ 2 ].getStatus = () => STATUS.failed;
+
+			expect( scheduler.requests.length ).toBe( 3 );
+
+			scheduler.cleanUp( now );
+
+			expect( scheduler.requests.length ).toBe( 1 );
+			expect( scheduler.requests[ 0 ].getStatus() ).toBe( STATUS.scheduled );
+		} );
+	} );
+
+	describe( 'resendTimeouts', () => {
+		it( 're-sends timed out requests', () => {
+			const fetch = jest.fn();
+			const scheduler = new Scheduler( fetch, 0 );
+
+			scheduler.scheduleRequest(
+				'resource1',
+				{ freshness: 5 * MINUTE, timeout: 5 * SECOND },
+				{},
+				threeMinutesAgo
+			);
+			scheduler.requests[ 0 ].getStatus = () => STATUS.timedOut;
+
+			fetch.mockReturnValue( Promise.resolve() );
+
+			return scheduler.resendTimeouts( now ).then( () => {
+				expect( fetch ).toHaveBeenCalledWith( [ scheduler.requests[ 0 ].resourceName ] );
+			} );
+		} );
+	} );
+
+	describe( 'setInterval', () => {
+		it( 'should be called by the constructor', () => {
+			const setInterval = jest.fn();
+			new Scheduler( () => {}, 1000, setInterval );
+
+			expect( setInterval ).toHaveBeenCalled();
+		} );
+
+		it( 'should provide a callback', () => {
+			let setIntervalCallback = null;
+			let setIntervalInterval = null;
+			const setInterval = ( callback, interval ) => {
+				setIntervalCallback = callback;
+				setIntervalInterval = interval;
+			};
+
+			const scheduler = new Scheduler( () => {}, 1000, setInterval );
+			scheduler.sendReadyRequests = jest.fn();
+			scheduler.resendTimeouts = jest.fn();
+			scheduler.cleanUp = jest.fn();
+			setIntervalCallback();
+
+			expect( setIntervalInterval ).toBe( 1000 );
+			expect( scheduler.sendReadyRequests ).toHaveBeenCalledTimes( 1 );
+			expect( scheduler.resendTimeouts ).toHaveBeenCalledTimes( 1 );
+			expect( scheduler.cleanUp ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+} );

--- a/packages/framework/src/client/scheduler.js
+++ b/packages/framework/src/client/scheduler.js
@@ -1,0 +1,140 @@
+import { find } from 'lodash';
+import ResourceRequest, { STATUS } from './resource-request';
+
+const DEFAULT_FETCH_INTERVAL = 5000; // Five seconds
+
+export default class Scheduler {
+	constructor(
+		fetch,
+		fetchInterval = DEFAULT_FETCH_INTERVAL,
+		setInterval = window.setInterval,
+	) {
+		this.fetch = fetch;
+		this.requests = [];
+		this.timerId = null;
+
+		if ( fetchInterval > 0 ) {
+			setInterval( () => {
+				this.cleanUp();
+				this.resendTimeouts();
+				this.sendReadyRequests();
+			}, fetchInterval );
+		}
+	}
+
+	/**
+	 * Finds a request that is either scheduled or overdue.
+	 * @param {string} resourceName The name of the resource to be read
+	 * @return {ResourceRequest} The scheduled request, or null if none found
+	 */
+	getScheduledRequest = ( resourceName ) => {
+		return find( this.requests, ( r ) => {
+			if ( resourceName === r.resourceName ) {
+				const status = r.getStatus();
+				return STATUS.scheduled === status || STATUS.overdue === status;
+			}
+			return false;
+		} );
+	}
+
+	/**
+	 * Finds requests that are in flight by resourceName
+	 * @param {string} resourceName The name of the resource to check
+	 * @return {Array} Any requests for the given resource which are currently in flight.
+	 */
+	getInFlightRequests = ( resourceName ) => {
+		return this.requests.filter( ( r ) => {
+			return ( resourceName === r.resourceName && STATUS.inFlight === r.getStatus() );
+		} );
+	}
+
+	/**
+	 * Schedule a read of a resource name according to the requirement set given.
+	 * @param {string} resourceName The name of the resource to be read
+	 * @param {Object} requirement The set of requirements (freshness, timeout)
+	 * @param {Object} resourceState The current snapshot of resource state
+	 * @param {Date} now The current time.
+	 */
+	scheduleRequest = ( resourceName, requirement, resourceState, now = new Date() ) => {
+		if ( this.getInFlightRequests( resourceName ).length > 0 ) {
+			// Do nothing, there's already a request in flight.
+			return;
+		}
+
+		const existingRequest = this.getScheduledRequest( resourceName );
+		if ( existingRequest ) {
+			existingRequest.addRequirement( requirement, resourceState, now );
+		} else {
+			this.requests.push( new ResourceRequest( resourceName, requirement, resourceState, now ) );
+		}
+	};
+
+	/**
+	 * Send a list of requests.
+	 * @param {Array} requests The list of requests to send.
+	 * @param {Date} now The current time.
+	 * @return {Promise} A promise returned from the fetch call.
+	 */
+	sendRequests = ( requests, now = new Date() ) => {
+		if ( requests.length > 0 ) {
+			const promise = this.fetch( requests.map( request => request.resourceName ) );
+
+			requests.forEach( ( request ) => {
+				request.requested( promise, now );
+			} );
+			return promise;
+		}
+		// No requests to send.
+		return Promise.resolve();
+	};
+
+	/**
+	 * Send any scheduled requests that are ready to be sent.
+	 * @param {Date} now The current time.
+	 * @return {Promise} A promise returned from the fetch call.
+	 */
+	sendReadyRequests = ( now = new Date() ) => {
+		const readyRequests = this.requests.filter( ( request ) => {
+			return this.isRequestReady( request, now );
+		} );
+		return this.sendRequests( readyRequests );
+	};
+
+	/**
+	 * Send any scheduled requests that are timed out.
+	 * @param {Date} now The current time.
+	 * @return {Promise} A promise returned from the fetch call.
+	 */
+	resendTimeouts = ( now = new Date() ) => {
+		const timedOutRequests = this.requests.filter( ( request ) => {
+			return STATUS.timedOut === request.getStatus( now );
+		} );
+		return this.sendRequests( timedOutRequests, now );
+	};
+
+	/**
+	 * Clear out completed and failed requests.
+	 * @param {Date} now The current time.
+	 */
+	cleanUp = ( now = new Date() ) => {
+		this.requests = this.requests.filter( ( request ) => {
+			const status = request.getStatus( now );
+			return STATUS.complete !== status && STATUS.failed !== status;
+		} );
+	};
+
+	/**
+	 * Checks if a request is ready.
+	 * @param {ResourceRequest} request The request to check.
+	 * @param {Date} now The current time.
+	 * @return {boolean} True if the request is ready to be sent, false otherwise.
+	 */
+	isRequestReady = ( request, now = new Date() ) => {
+		const status = request.getStatus();
+		if ( STATUS.scheduled == status || STATUS.overdue == status ) {
+			const timeLeft = request.getTimeLeft( now );
+			return ( timeLeft <= 0 );
+		}
+		return false;
+	};
+}

--- a/packages/react-provider/package-lock.json
+++ b/packages/react-provider/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fresh-data/react-provider",
-	"version": "0.6.0",
+	"version": "0.6.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {


### PR DESCRIPTION
WIP

Continuing in Step 3 of the refactor, this uses the scheduler and requests objects. This changes the ApiClient from tracking the requirements of each component to simply scheduling out requests based on components as they render. i.e. We don't refresh the list of requirements, we just make sure that the next fetch of needed resources is set up correctly. When that fetch happens, it updates the data state, which causes each component to re-render, sending its requirements once again, which starts the cycle over.

The advantage to this is simplification, and no longer needing to keep track of which component needs which resources in which way. We simply update our set of scheduled requests every time a component is rendered to make sure that they're taken care of. If the component is unmounted before the request returns, then the component will simply not be there to require that resource next time around.

To Test:
This is still a work in progress and testing instructions have yet to be written.

