### PR TITLE
Render-based refactor: Step 1

### DIFF
--- a/packages/framework/src/client/__tests__/resource-request.spec.js
+++ b/packages/framework/src/client/__tests__/resource-request.spec.js
@@ -1,0 +1,218 @@
+import ResourceRequest, { STATUS } from '../resource-request';
+import { MINUTE, SECOND } from '../../utils/constants';
+
+describe( 'ResourceRequest', () => {
+	const now = new Date();
+	const sixMinutesAgo = new Date( now.getTime() - ( 6 * MINUTE ) );
+	const threeMinutesAgo = new Date( now.getTime() - ( 3 * MINUTE ) );
+	const tenSecondsAgo = new Date( now.getTime() - ( 10 * SECOND ) );
+	const twoMinutesFromNow = new Date( now.getTime() + ( 2 * MINUTE ) );
+
+	describe( 'constructor', () => {
+		it( 'creates a request to be fetched immediately', () => {
+			const requirement = {};
+			const resourceState = {};
+
+			const request = new ResourceRequest( 'resource1', requirement, resourceState, now );
+
+			expect( request.getStatus() ).toBe( STATUS.overdue );
+			expect( request.time ).toBe( now );
+		} );
+
+		it( 'creates a scheduled request for when freshness expires', () => {
+			const requirement = { freshness: 5 * MINUTE, timeout: 3 * SECOND };
+			const resourceState = { lastReceived: threeMinutesAgo };
+
+			const request = new ResourceRequest( 'resource1', requirement, resourceState, now );
+
+			expect( request.getStatus( now ) ).toBe( STATUS.scheduled );
+			expect( request.time ).toEqual( twoMinutesFromNow );
+		} );
+
+		it( 'creates an unnecessary request when already fetched and no freshness specified', () => {
+			const requirement = { timeout: 3 * SECOND };
+			const resourceState = { lastReceived: threeMinutesAgo };
+
+			const request = new ResourceRequest( 'resource1', requirement, resourceState, now );
+
+			expect( request.getStatus( now ) ).toBe( STATUS.unnecessary );
+			expect( request.time ).toBe( null );
+		} );
+	} );
+
+	describe( 'getStatus', () => {
+		it( 'shows scheduled', () => {
+			const requirement = { freshness: 5 * MINUTE, timeout: 3 * SECOND };
+			const resourceState = { lastReceived: threeMinutesAgo };
+
+			const request = new ResourceRequest( 'resource1', requirement, resourceState, now );
+
+			expect( request.getStatus( now ) ).toBe( STATUS.scheduled );
+		} );
+
+		it( 'shows overdue', () => {
+			const requirement = { freshness: 5 * MINUTE, timeout: 3 * SECOND };
+			const resourceState = { lastReceived: sixMinutesAgo };
+
+			const request = new ResourceRequest( 'resource1', requirement, resourceState, now );
+
+			expect( request.getStatus( now ) ).toBe( STATUS.overdue );
+		} );
+
+		it( 'shows inFlight', () => {
+			const requirement = { freshness: 5 * MINUTE, timeout: 3 * SECOND };
+			const resourceState = { lastReceived: sixMinutesAgo };
+
+			const request = new ResourceRequest( 'resource1', requirement, resourceState, now );
+			request.requested( Promise.resolve(), now );
+
+			expect( request.getStatus( now ) ).toBe( STATUS.inFlight );
+
+			return request.promise;
+		} );
+
+		it( 'shows complete', () => {
+			const requirement = { freshness: 5 * MINUTE, timeout: 3 * SECOND };
+			const resourceState = { lastReceived: sixMinutesAgo };
+
+			const request = new ResourceRequest( 'resource1', requirement, resourceState, now );
+			request.requested( Promise.resolve(), now );
+
+			return request.promise.then( () => {
+				expect( request.getStatus( now ) ).toBe( STATUS.complete );
+			} );
+		} );
+
+		it( 'shows failed', () => {
+			const requirement = { freshness: 5 * MINUTE, timeout: 3 * SECOND };
+			const resourceState = { lastReceived: sixMinutesAgo };
+
+			const request = new ResourceRequest( 'resource1', requirement, resourceState, now );
+			request.requested( Promise.reject( 'error message' ), now );
+
+			return request.promise.catch( () => {
+				expect( request.getStatus( now ) ).toBe( STATUS.failed );
+				expect( request.error ).toBe( 'error message' );
+			} );
+		} );
+
+		it( 'shows timed out', () => {
+			const requirement = { freshness: 5 * MINUTE, timeout: 3 * SECOND };
+			const resourceState = { lastReceived: sixMinutesAgo };
+
+			const request = new ResourceRequest( 'resource1', requirement, resourceState, tenSecondsAgo );
+			request.requested( Promise.resolve(), tenSecondsAgo );
+
+			expect( request.getStatus( now ) ).toBe( STATUS.timedOut );
+
+			return request.promise;
+		} );
+	} );
+
+	describe( 'getTimeLeft', () => {
+		it( 'returns a positive value for a scheduled request', () => {
+			const requirement = { freshness: 5 * MINUTE, timeout: 3 * SECOND };
+			const resourceState = { lastReceived: threeMinutesAgo };
+
+			const request = new ResourceRequest( 'resource1', requirement, resourceState, now );
+
+			expect( request.getStatus( now ) ).toBe( STATUS.scheduled );
+			expect( request.getTimeLeft() ).toBeLessThan( 2 * MINUTE );
+		} );
+
+		it( 'returns a negative value for an overdue request', () => {
+			const requirement = { freshness: 2 * MINUTE, timeout: 3 * SECOND };
+			const resourceState = { lastReceived: threeMinutesAgo };
+
+			const request = new ResourceRequest( 'resource1', requirement, resourceState, now );
+
+			expect( request.getStatus( now ) ).toBe( STATUS.overdue );
+			expect( request.getTimeLeft( now ) ).toBe( -( 1 * MINUTE ) );
+		} );
+	} );
+
+	describe( 'requested', () => {
+		it( 'progresses through success flow correctly', () => {
+			const request = new ResourceRequest( 'resource1', {}, {}, tenSecondsAgo );
+
+			expect( request.getStatus( now ) ).toBe( STATUS.overdue );
+
+			let promiseResolve;
+			const promise = new Promise( ( resolve ) => {
+				promiseResolve = resolve;
+			} );
+
+			request.requested( promise );
+			expect( request.getStatus() ).toBe( STATUS.inFlight );
+
+			promiseResolve();
+
+			return promise.then( () => {
+				expect( request.getStatus() ).toBe( STATUS.complete );
+			} );
+		} );
+
+		it( 'progresses through error flow correctly', () => {
+			const request = new ResourceRequest( 'resource1', {}, {}, tenSecondsAgo );
+
+			expect( request.getStatus( now ) ).toBe( STATUS.overdue );
+
+			let promiseReject;
+			const promise = new Promise( ( resolve, reject ) => {
+				promiseReject = reject;
+			} );
+
+			request.requested( promise, now );
+			expect( request.getStatus( now ) ).toBe( STATUS.inFlight );
+
+			promiseReject( 'error message' );
+
+			return promise.catch( () => {
+				expect( request.getStatus( now ) ).toBe( STATUS.failed );
+				expect( request.error ).toBe( 'error message' );
+			} );
+		} );
+	} );
+
+	describe( 'addRequirement', () => {
+		it( 'reschedules earlier', () => {
+			const requirement1 = { freshness: 5 * MINUTE, timeout: 3 * SECOND };
+			const requirement2 = { freshness: 4 * MINUTE, timeout: 3 * SECOND };
+			const resourceState = { lastReceived: threeMinutesAgo };
+
+			const request = new ResourceRequest( 'resource1', requirement1, resourceState, tenSecondsAgo );
+			expect( request.getStatus( now ) ).toBe( STATUS.scheduled );
+			expect( request.getTimeLeft( now ) ).toBe( 2 * MINUTE );
+
+			expect( request.addRequirement( requirement2, resourceState, now ) ).toBeTruthy();
+			expect( request.getStatus( now ) ).toBe( STATUS.scheduled );
+			expect( request.getTimeLeft( now ) ).toBe( 1 * MINUTE );
+		} );
+
+		it( 'does not reschedule if request is already adequate', () => {
+			const requirement1 = { freshness: 4 * MINUTE, timeout: 3 * SECOND };
+			const requirement2 = { freshness: 5 * MINUTE, timeout: 3 * SECOND };
+			const resourceState = { lastReceived: threeMinutesAgo };
+
+			const request = new ResourceRequest( 'resource1', requirement1, resourceState, tenSecondsAgo );
+			expect( request.getStatus( now ) ).toBe( STATUS.scheduled );
+			expect( request.getTimeLeft( now ) ).toBe( 1 * MINUTE );
+
+			expect( request.addRequirement( requirement2, resourceState, now ) ).toBeTruthy();
+			expect( request.getStatus( now ) ).toBe( STATUS.scheduled );
+			expect( request.getTimeLeft( now ) ).toBe( 1 * MINUTE );
+		} );
+
+		it( 'fails if the request is not scheduled', () => {
+			const requirement1 = { timeout: 3 * SECOND };
+			const requirement2 = { freshness: 4 * MINUTE, timeout: 3 * SECOND };
+			const resourceState = { lastReceived: threeMinutesAgo };
+
+			const request = new ResourceRequest( 'resource1', requirement1, resourceState, tenSecondsAgo );
+			expect( request.getStatus( now ) ).toBe( STATUS.unnecessary );
+
+			expect( request.addRequirement( requirement2, resourceState, now ) ).toBeFalsy();
+			expect( request.getStatus( now ) ).toBe( STATUS.unnecessary );
+		} );
+	} );
+} );

--- a/packages/framework/src/client/resource-request.js
+++ b/packages/framework/src/client/resource-request.js
@@ -1,0 +1,111 @@
+import debugFactory from 'debug';
+import { isDateEarlier } from '../utils/dates';
+import { SECOND } from '../utils/constants';
+
+const DEFAULT_TIMEOUT = 30 * SECOND;
+
+export const STATUS = {
+	failed: 'Failed',
+	inFlight: 'In Flight',
+	complete: 'Complete',
+	overdue: 'Overdue',
+	scheduled: 'Scheduled',
+	timedOut: 'Timed Out',
+	unnecessary: 'Unnecessary',
+};
+
+export default class ResourceRequest {
+	constructor( resourceName, requirement, resourceState, now ) {
+		this.debug = debugFactory( 'fresh-data:request(' + resourceName + ')' );
+		this.resourceName = resourceName;
+		this.time = calculateRequestTime( requirement, resourceState, now );
+		this.timeout = requirement.timeout || DEFAULT_TIMEOUT;
+		this.promise = null;
+		this.timeRequested = null;
+		this.timeCompleted = null;
+		this.error = null;
+
+		if ( this.time ) {
+			const seconds = ( this.time.getTime() - now.getTime() ) / 1000.0;
+			this.debug( `New request for "${ this.resourceName }" to be fetched in ${ seconds }s` );
+		}
+	}
+
+	addRequirement( requirement, resourceState, now ) {
+		const status = this.getStatus( now );
+		if ( STATUS.scheduled === status || STATUS.overdue === status ) {
+			const requestTime = calculateRequestTime( requirement, resourceState, now );
+			if ( isDateEarlier( this.time, requestTime ) ) {
+				this.time = requestTime;
+				const seconds = ( this.time.getTime() - now.getTime() ) / 1000.0;
+				this.debug( `Rescheduling request for "${ this.resourceName }" to fetched in ${ seconds }s` );
+			}
+			this.timeout = Math.min( this.timeout, requirement.timeout || DEFAULT_TIMEOUT );
+			return true;
+		}
+		this.debug( `Cannot add requirement to request with "${ this.getStatus( now ) }" status` );
+		return false;
+	}
+
+	getStatus = ( now = new Date() ) => {
+		if ( ! this.time ) {
+			return STATUS.unnecessary;
+		}
+		if ( this.timeRequested ) {
+			if ( this.timeCompleted ) {
+				if ( this.error ) {
+					return STATUS.failed;
+				}
+				return STATUS.complete;
+			}
+			if ( now.getTime() - this.timeRequested > this.timeout ) {
+				return STATUS.timedOut;
+			}
+			return STATUS.inFlight;
+		}
+		if ( isDateEarlier( now, this.time ) ) {
+			return STATUS.overdue;
+		}
+		return STATUS.scheduled;
+	}
+
+	getTimeLeft = ( now = new Date() ) => {
+		return this.time.getTime() - now.getTime();
+	}
+
+	requested = ( promise, now = new Date() ) => {
+		this.debug( `Request for ${ this.resourceName } submitted...` );
+		this.timeRequested = now;
+		this.promise = promise;
+		this.promise.then( this.requestComplete, this.requestFailed );
+	}
+
+	requestComplete = () => {
+		this.promise = null;
+		this.timeCompleted = new Date();
+		const seconds = ( this.timeCompleted.getTime() - this.timeRequested.getTime() ) / 1000.0;
+		this.debug( `Request for ${ this.resourceName } completed in ${ seconds }s` );
+	}
+
+	requestFailed = ( error ) => {
+		this.promise = null;
+		this.timeCompleted = new Date();
+		this.error = error;
+		this.debug( `Request for ${ this.resourceName } failed: `, error );
+	}
+}
+
+function calculateRequestTime( requirement, resourceState, now ) {
+	const { freshness } = requirement;
+	const { lastReceived } = resourceState;
+
+	if ( ! lastReceived ) {
+		// Never fetched, so fetch now.
+		return now;
+	}
+	if ( freshness ) {
+		// Fetch after freshness expires.
+		return new Date( lastReceived.getTime() + freshness );
+	}
+	return null;
+}

--- a/packages/framework/src/utils/__tests__/dates.spec.js
+++ b/packages/framework/src/utils/__tests__/dates.spec.js
@@ -1,0 +1,30 @@
+import { isDateEarlier } from '../dates';
+
+describe( 'isDateEarlier', () => {
+	it( 'returns false an exact match', () => {
+		const now = new Date();
+		expect( isDateEarlier( now, now ) ).toBe( false );
+	} );
+
+	it( 'returns true if no existing date', () => {
+		const now = new Date();
+		expect( isDateEarlier( null, now ) ).toBe( true );
+	} );
+
+	it( 'returns false if no new date', () => {
+		const now = new Date();
+		expect( isDateEarlier( now, null ) ).toBe( false );
+	} );
+
+	it( 'returns true for one millisecond earlier', () => {
+		const now = new Date();
+		const earlier = new Date( now.getTime() - 1 );
+		expect( isDateEarlier( now, earlier ) ).toBe( true );
+	} );
+
+	it( 'returns false for one millisecond later', () => {
+		const now = new Date();
+		const earlier = new Date( now.getTime() + 1 );
+		expect( isDateEarlier( now, earlier ) ).toBe( false );
+	} );
+} );

--- a/packages/framework/src/utils/__tests__/dates.spec.js
+++ b/packages/framework/src/utils/__tests__/dates.spec.js
@@ -24,7 +24,7 @@ describe( 'isDateEarlier', () => {
 
 	it( 'returns false for one millisecond later', () => {
 		const now = new Date();
-		const earlier = new Date( now.getTime() + 1 );
-		expect( isDateEarlier( now, earlier ) ).toBe( false );
+		const later = new Date( now.getTime() + 1 );
+		expect( isDateEarlier( now, later ) ).toBe( false );
 	} );
 } );

--- a/packages/framework/src/utils/dates.js
+++ b/packages/framework/src/utils/dates.js
@@ -1,0 +1,19 @@
+
+/**
+ * Checks if a new date is earlier than an existing one.
+ * @param {Date} existingDate The existing date to check against
+ * @param {Date} newDate The new date to check against the existing one
+ * @return {boolean} True if the new date is earlier, false otherwise
+ */
+export function isDateEarlier( existingDate, newDate ) {
+	if ( existingDate === newDate ) {
+		return false;
+	}
+	if ( ! existingDate && newDate ) {
+		return true;
+	}
+	if ( ! newDate && existingDate ) {
+		return false;
+	}
+	return ( newDate.getTime() < existingDate.getTime() );
+}


### PR DESCRIPTION
Partially addresses #203 

This is Step 1 of the Render-based refactor. It involves creating a new ResourceRequest class to track individual requests of resource keys. Note that this is a theoretical request and not necessarily 1:1 for network requests. A single network request can fulfill more than one resource request. In that case, multiple ResourceRequest objects will have references to the same request promise.

In this step, no actual behavior of the framework is changed. This only adds the ResourceRequest and corresponding tests.

To Test:
1. `npm install`
2. `npm run bootstrap`
3. `npm run lint`
4. `npm run test`
