### PR TITLE
Render-based refactor: Step 2

### DIFF
--- a/packages/framework/package-lock.json
+++ b/packages/framework/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fresh-data/framework",
-	"version": "0.6.0",
+	"version": "0.6.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/framework/src/client/__tests__/scheduler.spec.js
+++ b/packages/framework/src/client/__tests__/scheduler.spec.js
@@ -1,6 +1,6 @@
 import { isEmpty } from 'lodash';
 import Scheduler from '../scheduler';
-import { STATUS } from '../resource-request';
+import ResourceRequest, { STATUS } from '../resource-request';
 import { MINUTE, SECOND } from '../../utils/constants';
 
 // TODO: Handle timeouts
@@ -12,15 +12,222 @@ describe( 'Scheduler', () => {
 
 	describe( 'constructor', () => {
 		it( 'creates an array of requests', () => {
-			const scheduler = new Scheduler( () => {}, 0 );
+			const scheduler = new Scheduler( () => {}, () => {}, () => {} );
 
 			expect( scheduler.requests ).toEqual( [] );
+		} );
+
+		it( 'initializes timeout variables', () => {
+			const setTimeout = () => {};
+			const clearTimeout = () => {};
+			const scheduler = new Scheduler( () => {}, setTimeout, clearTimeout );
+
+			expect( scheduler.setTimeout ).toBe( setTimeout );
+			expect( scheduler.clearTimeout ).toBe( clearTimeout );
+			expect( scheduler.timeoutId ).toBe( null );
+			expect( scheduler.nextRequestTime ).toBe( null );
+		} );
+
+		it( 'defaults to window.setTimeout and window.clearTimeout', () => {
+			const scheduler = new Scheduler( () => {} );
+
+			expect( scheduler.setTimeout ).toBe( window.setTimeout );
+			expect( scheduler.clearTimeout ).toBe( window.clearTimeout );
+		} );
+	} );
+
+	describe( 'getNextRequestDelay', () => {
+		it( 'returns null when no requests are scheduled/overdue', () => {
+			const scheduler = new Scheduler( () => {}, () => {}, () => {} );
+
+			expect( scheduler.getNextRequestDelay() ).toBeNull();
+
+			scheduler.scheduleRequest( 'completeResource', {}, {}, now );
+			scheduler.requests[ 0 ].getStatus = () => STATUS.complete;
+
+			expect( scheduler.getNextRequestDelay( now ) ).toBeNull();
+		} );
+
+		it( 'returns zero when a request is overdue', () => {
+			const scheduler = new Scheduler( () => {}, () => {}, () => {} );
+
+			scheduler.scheduleRequest( 'resource1', {}, {}, threeMinutesAgo );
+
+			expect( scheduler.getNextRequestDelay( now ) ).toBe( 0 );
+		} );
+
+		it( 'returns a positive number when a request is scheduled', () => {
+			const scheduler = new Scheduler( () => {}, () => {}, () => {} );
+
+			scheduler.scheduleRequest( 'resource1', { freshness: 5 * MINUTE }, { lastReceived: threeMinutesAgo }, now );
+
+			expect( scheduler.getNextRequestDelay( now ) / MINUTE ).toBeCloseTo( 2, 2 );
+		} );
+
+		it( 'returns zero when a new request is scheduled that is immediately due', () => {
+			const scheduler = new Scheduler( () => {}, () => {}, () => {} );
+
+			scheduler.scheduleRequest( 'resource1', { freshness: 5 * MINUTE }, { lastReceived: threeMinutesAgo }, now );
+			scheduler.scheduleRequest( 'resource1', {}, {}, now );
+
+			expect( scheduler.getNextRequestDelay( now ) ).toBe( 0 );
+		} );
+
+		it( 'returns the same number when a new request that is scheduled later is added', () => {
+			const scheduler = new Scheduler( () => {}, () => {}, () => {} );
+
+			scheduler.scheduleRequest( 'resource1', { freshness: 5 * MINUTE }, { lastReceived: threeMinutesAgo }, now );
+			const delayBefore = scheduler.getNextRequestDelay( now );
+
+			scheduler.scheduleRequest( 'resource1', { freshness: 30 * MINUTE }, { lastReceived: fourMinutesAgo }, now );
+			const delayAfter = scheduler.getNextRequestDelay( now );
+
+			expect( delayAfter ).toBe( delayBefore );
+		} );
+	} );
+
+	describe( 'updateDelay', () => {
+		it( 'Does not stop or set timeout when no requests are scheduled/overdue', () => {
+			const setTimeout = jest.fn();
+			const scheduler = new Scheduler( () => {}, setTimeout, () => {} );
+			scheduler.stop = jest.fn();
+
+			scheduler.updateDelay();
+
+			expect( setTimeout ).not.toHaveBeenCalled();
+			expect( scheduler.stop ).not.toHaveBeenCalled();
+		} );
+
+		it( 'Sets timeout when a request is scheduled', () => {
+			const setTimeout = jest.fn();
+			const scheduler = new Scheduler( () => {}, setTimeout, () => {} );
+
+			scheduler.requests.push(
+				new ResourceRequest( 'resource1', { freshness: 5 * MINUTE }, { lastReceived: threeMinutesAgo }, now )
+			);
+			scheduler.updateDelay( now );
+
+			expect( setTimeout ).toHaveBeenCalledTimes( 1 );
+			expect( setTimeout.mock.calls[ 0 ][ 0 ] ).toBe( scheduler.processRequests );
+			expect( setTimeout.mock.calls[ 0 ][ 1 ] / MINUTE ).toBeCloseTo( 2, 2 );
+		} );
+
+		it( 'Sets zero timeout when a request is overdue', () => {
+			const setTimeout = jest.fn();
+			const scheduler = new Scheduler( () => {}, setTimeout, () => {} );
+
+			scheduler.requests.push(
+				new ResourceRequest( 'resource1', { freshness: 2 * MINUTE }, { lastReceived: threeMinutesAgo }, now )
+			);
+			scheduler.updateDelay( now );
+
+			expect( setTimeout ).toHaveBeenCalledTimes( 1 );
+			expect( setTimeout.mock.calls[ 0 ][ 0 ] ).toBe( scheduler.processRequests );
+			expect( setTimeout.mock.calls[ 0 ][ 1 ] ).toBe( 0 );
+		} );
+
+		it( 'Stops timeout and starts a new timeout when a newer request is scheduled', () => {
+			const setTimeout = jest.fn();
+			const scheduler = new Scheduler( () => {}, setTimeout, () => {} );
+			scheduler.stop = jest.fn();
+
+			scheduler.requests.push(
+				new ResourceRequest( 'resource1', { freshness: 5 * MINUTE }, { lastReceived: threeMinutesAgo }, now )
+			);
+			scheduler.updateDelay( now );
+
+			expect( setTimeout ).toHaveBeenCalledTimes( 1 );
+			expect( scheduler.stop ).toHaveBeenCalledTimes( 1 );
+
+			scheduler.requests.push(
+				new ResourceRequest( 'resource1', { freshness: 4 * MINUTE }, { lastReceived: threeMinutesAgo }, now )
+			);
+			scheduler.updateDelay( now );
+
+			expect( setTimeout ).toHaveBeenCalledTimes( 2 );
+			expect( scheduler.stop ).toHaveBeenCalledTimes( 2 );
+
+			expect( setTimeout.mock.calls[ 1 ][ 0 ] ).toBe( scheduler.processRequests );
+			expect( setTimeout.mock.calls[ 1 ][ 1 ] / MINUTE ).toBeCloseTo( 1, 2 );
+		} );
+
+		it( 'Stops timeout and starts a new zero timeout when a immediately due request is scheduled', () => {
+			const setTimeout = jest.fn();
+			const scheduler = new Scheduler( () => {}, setTimeout, () => {} );
+			scheduler.stop = jest.fn();
+
+			scheduler.requests.push(
+				new ResourceRequest( 'resource1', { freshness: 5 * MINUTE }, { lastReceived: threeMinutesAgo }, now )
+			);
+			scheduler.updateDelay( now );
+
+			expect( setTimeout ).toHaveBeenCalledTimes( 1 );
+			expect( scheduler.stop ).toHaveBeenCalledTimes( 1 );
+
+			scheduler.requests.push(
+				new ResourceRequest( 'resource2', {}, {}, now )
+			);
+			scheduler.updateDelay( now );
+
+			expect( setTimeout ).toHaveBeenCalledTimes( 2 );
+			expect( scheduler.stop ).toHaveBeenCalledTimes( 2 );
+
+			expect( setTimeout.mock.calls[ 1 ][ 0 ] ).toBe( scheduler.processRequests );
+			expect( setTimeout.mock.calls[ 1 ][ 1 ] ).toBe( 0 );
+		} );
+
+		it( 'Stops timeout and does not start a new one if there are no longer any requests scheduled/overdue', () => {
+			const setTimeout = jest.fn();
+			const scheduler = new Scheduler( () => {}, setTimeout, () => {} );
+			scheduler.stop = jest.fn();
+
+			scheduler.requests.push(
+				new ResourceRequest( 'resource1', { freshness: 5 * MINUTE }, { lastReceived: fourMinutesAgo }, threeMinutesAgo )
+			);
+			scheduler.updateDelay( threeMinutesAgo );
+
+			expect( setTimeout ).toHaveBeenCalledTimes( 1 );
+			expect( scheduler.stop ).toHaveBeenCalledTimes( 1 );
+
+			scheduler.requests[ 0 ].getStatus = () => STATUS.complete;
+			scheduler.updateDelay( now );
+
+			expect( scheduler.stop ).toHaveBeenCalledTimes( 2 );
+			expect( setTimeout ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+
+	describe( 'stop', () => {
+		it( 'Does nothing when no timer is set', () => {
+			const setTimeout = () => 123;
+			const clearTimeout = jest.fn();
+			const scheduler = new Scheduler( () => {}, setTimeout, clearTimeout );
+
+			scheduler.stop();
+
+			expect( clearTimeout ).not.toHaveBeenCalled();
+		} );
+
+		it( 'Stops the timer when it is set', () => {
+			const setTimeout = () => 123;
+			const clearTimeout = jest.fn();
+			const scheduler = new Scheduler( () => {}, setTimeout, clearTimeout );
+
+			scheduler.requests.push(
+				new ResourceRequest( 'resource1', { freshness: 5 * MINUTE }, { lastReceived: threeMinutesAgo }, now )
+			);
+			scheduler.updateDelay( now );
+
+			scheduler.stop();
+
+			expect( clearTimeout ).toHaveBeenCalledTimes( 1 );
+			expect( clearTimeout ).toHaveBeenCalledWith( 123 );
 		} );
 	} );
 
 	describe( 'scheduleRequest', () => {
 		it( 'creates an overdue request when no existing state exists', () => {
-			const scheduler = new Scheduler( () => {}, 0 );
+			const scheduler = new Scheduler( () => {}, () => {}, () => {} );
 			const resourceName = 'resource1';
 
 			scheduler.scheduleRequest( resourceName, {}, {}, threeMinutesAgo );
@@ -31,7 +238,7 @@ describe( 'Scheduler', () => {
 		} );
 
 		it( 'creates a scheduled request when state exists', () => {
-			const scheduler = new Scheduler( () => {}, 0 );
+			const scheduler = new Scheduler( () => {}, () => {}, () => {} );
 			const resourceName = 'resource1';
 			const requirement = { freshness: 5 * MINUTE };
 			const resourceState = { lastReceived: threeMinutesAgo };
@@ -45,7 +252,7 @@ describe( 'Scheduler', () => {
 		} );
 
 		it( 'updates an existing scheduled request with a new scheduled requirement', () => {
-			const scheduler = new Scheduler( () => {}, 0 );
+			const scheduler = new Scheduler( () => {}, () => {}, () => {} );
 			const resourceName = 'resource1';
 			const requirement1 = { freshness: 5 * MINUTE };
 			const requirement2 = { freshness: 4 * MINUTE };
@@ -66,7 +273,7 @@ describe( 'Scheduler', () => {
 		} );
 
 		it( 'does not add a new request when an identical previous request is already in flight', () => {
-			const scheduler = new Scheduler( () => {}, 0 );
+			const scheduler = new Scheduler( () => {}, () => {}, () => {} );
 			const resourceName = 'resource1';
 			const requirement1 = { freshness: 5 * MINUTE };
 			const requirement2 = { freshness: 4 * MINUTE };
@@ -86,7 +293,7 @@ describe( 'Scheduler', () => {
 
 	describe( 'getScheduledRequest', () => {
 		it( 'finds a scheduled request', () => {
-			const scheduler = new Scheduler( () => {}, 0 );
+			const scheduler = new Scheduler( () => {}, () => {}, () => {} );
 			const resourceName = 'resource1';
 			const requirement1 = { freshness: 5 * MINUTE };
 			const resourceState = { lastReceived: threeMinutesAgo };
@@ -96,11 +303,23 @@ describe( 'Scheduler', () => {
 			expect( request.resourceName ).toBe( resourceName );
 			expect( request.getStatus() ).toBe( STATUS.scheduled );
 		} );
+
+		it( 'finds an overdue request', () => {
+			const scheduler = new Scheduler( () => {}, () => {}, () => {} );
+			const resourceName = 'resource1';
+			const requirement1 = { freshness: 2 * MINUTE };
+			const resourceState = { lastReceived: threeMinutesAgo };
+
+			scheduler.scheduleRequest( resourceName, requirement1, resourceState, now );
+			const request = scheduler.getScheduledRequest( resourceName );
+			expect( request.resourceName ).toBe( resourceName );
+			expect( request.getStatus() ).toBe( STATUS.overdue );
+		} );
 	} );
 
 	describe( 'getInFlightRequests', () => {
 		it( 'finds any requests for a resource that are currently in-flight', () => {
-			const scheduler = new Scheduler( () => {}, 0 );
+			const scheduler = new Scheduler( () => {}, () => {}, () => {} );
 			const resourceName = 'resource1';
 			const requirement1 = { freshness: 5 * MINUTE };
 			const resourceState = { lastReceived: threeMinutesAgo };
@@ -118,7 +337,7 @@ describe( 'Scheduler', () => {
 
 	describe( 'isRequestReady', () => {
 		it( 'returns false if the resource is still fresh enough', () => {
-			const scheduler = new Scheduler( () => {}, 0 );
+			const scheduler = new Scheduler( () => {}, () => {}, () => {} );
 			const resourceName = 'resource1';
 			const requirement1 = { freshness: 5 * MINUTE };
 			const resourceState = { lastReceived: threeMinutesAgo };
@@ -128,7 +347,7 @@ describe( 'Scheduler', () => {
 		} );
 
 		it( 'returns true if the resource is not fresh enough', () => {
-			const scheduler = new Scheduler( () => {}, 0 );
+			const scheduler = new Scheduler( () => {}, () => {}, () => {} );
 			const resourceName = 'resource1';
 			const requirement1 = { freshness: 2 * MINUTE };
 			const resourceState = { lastReceived: threeMinutesAgo };
@@ -138,7 +357,7 @@ describe( 'Scheduler', () => {
 		} );
 
 		it( 'returns true if the resource has not yet been fetched', () => {
-			const scheduler = new Scheduler( () => {}, 0 );
+			const scheduler = new Scheduler( () => {}, () => {}, () => {} );
 			const resourceName = 'resource1';
 			const requirement1 = {};
 			const resourceState = {};
@@ -148,7 +367,7 @@ describe( 'Scheduler', () => {
 		} );
 
 		it( 'returns false if the resource status is anything but scheduled or overdue', () => {
-			const scheduler = new Scheduler( () => {}, 0 );
+			const scheduler = new Scheduler( () => {}, () => {}, () => {} );
 			const resourceName = 'resource1';
 			const requirement1 = {};
 			const resourceState = {};
@@ -175,7 +394,7 @@ describe( 'Scheduler', () => {
 
 	describe( 'sendReadyRequests', () => {
 		it( 'does nothing when there are no requests in queue', () => {
-			const scheduler = new Scheduler( () => {}, 0 );
+			const scheduler = new Scheduler( () => {}, () => {}, () => {} );
 
 			expect( isEmpty( scheduler.requests ) ).toBeTruthy();
 			scheduler.sendReadyRequests();
@@ -183,7 +402,7 @@ describe( 'Scheduler', () => {
 		} );
 
 		it( 'does nothing when there are no scheduled or overdue requests in queue', () => {
-			const scheduler = new Scheduler( () => {}, 0 );
+			const scheduler = new Scheduler( () => {}, () => {}, () => {} );
 
 			scheduler.scheduleRequest( 'inFlightResource', {}, {}, now );
 			scheduler.requests[ 0 ].getStatus = () => STATUS.inFlight;
@@ -206,7 +425,7 @@ describe( 'Scheduler', () => {
 
 		it( 'Calls fetch with resource names', () => {
 			const fetch = jest.fn();
-			const scheduler = new Scheduler( fetch, 0 );
+			const scheduler = new Scheduler( fetch, () => {}, () => {} );
 
 			scheduler.scheduleRequest(
 				'resource1',
@@ -236,7 +455,7 @@ describe( 'Scheduler', () => {
 
 		it( 'calls request.requested for each ready request', () => {
 			const fetch = jest.fn();
-			const scheduler = new Scheduler( fetch, 0 );
+			const scheduler = new Scheduler( fetch, () => {}, () => {} );
 
 			scheduler.scheduleRequest(
 				'resource1',
@@ -265,8 +484,22 @@ describe( 'Scheduler', () => {
 	} );
 
 	describe( 'cleanUp', () => {
+		it( 'does not clear scheduled requests', () => {
+			const scheduler = new Scheduler( () => {}, () => {}, () => {} );
+
+			scheduler.scheduleRequest( 'scheduledResource', {}, {}, now );
+			scheduler.requests[ 0 ].getStatus = () => STATUS.scheduled;
+
+			expect( scheduler.requests.length ).toBe( 1 );
+
+			scheduler.cleanUp();
+
+			expect( scheduler.requests.length ).toBe( 1 );
+			expect( scheduler.requests[ 0 ].getStatus() ).toBe( STATUS.scheduled );
+		} );
+
 		it( 'clears out completed and failed requests', () => {
-			const scheduler = new Scheduler( () => {}, 0 );
+			const scheduler = new Scheduler( () => {}, () => {}, () => {} );
 
 			scheduler.scheduleRequest( 'scheduledResource', {}, {}, now );
 			scheduler.requests[ 0 ].getStatus = () => STATUS.scheduled;
@@ -287,9 +520,25 @@ describe( 'Scheduler', () => {
 	} );
 
 	describe( 'resendTimeouts', () => {
+		it( 'does nothing when no requests are timed out', () => {
+			const fetch = jest.fn();
+			const scheduler = new Scheduler( fetch, () => {}, () => {} );
+
+			scheduler.scheduleRequest(
+				'resource1',
+				{ freshness: 5 * MINUTE, timeout: 5 * SECOND },
+				{},
+				threeMinutesAgo
+			);
+
+			return scheduler.resendTimeouts().then( () => {
+				expect( fetch ).not.toHaveBeenCalled();
+			} );
+		} );
+
 		it( 're-sends timed out requests', () => {
 			const fetch = jest.fn();
-			const scheduler = new Scheduler( fetch, 0 );
+			const scheduler = new Scheduler( fetch, () => {}, () => {} );
 
 			scheduler.scheduleRequest(
 				'resource1',
@@ -307,32 +556,20 @@ describe( 'Scheduler', () => {
 		} );
 	} );
 
-	describe( 'setInterval', () => {
-		it( 'should be called by the constructor', () => {
-			const setInterval = jest.fn();
-			new Scheduler( () => {}, 1000, setInterval );
-
-			expect( setInterval ).toHaveBeenCalled();
-		} );
-
-		it( 'should provide a callback', () => {
-			let setIntervalCallback = null;
-			let setIntervalInterval = null;
-			const setInterval = ( callback, interval ) => {
-				setIntervalCallback = callback;
-				setIntervalInterval = interval;
-			};
-
-			const scheduler = new Scheduler( () => {}, 1000, setInterval );
+	describe( 'processRequests', () => {
+		it( 'should clean up, send ready requests, resend timeouts, and update the delay', () => {
+			const scheduler = new Scheduler( () => {}, () => {}, () => {} );
+			scheduler.cleanUp = jest.fn();
 			scheduler.sendReadyRequests = jest.fn();
 			scheduler.resendTimeouts = jest.fn();
-			scheduler.cleanUp = jest.fn();
-			setIntervalCallback();
+			scheduler.updateDelay = jest.fn();
 
-			expect( setIntervalInterval ).toBe( 1000 );
+			scheduler.processRequests();
+
+			expect( scheduler.cleanUp ).toHaveBeenCalledTimes( 1 );
 			expect( scheduler.sendReadyRequests ).toHaveBeenCalledTimes( 1 );
 			expect( scheduler.resendTimeouts ).toHaveBeenCalledTimes( 1 );
-			expect( scheduler.cleanUp ).toHaveBeenCalledTimes( 1 );
+			expect( scheduler.updateDelay ).toHaveBeenCalledTimes( 1 );
 		} );
 	} );
 } );

--- a/packages/framework/src/client/__tests__/scheduler.spec.js
+++ b/packages/framework/src/client/__tests__/scheduler.spec.js
@@ -1,0 +1,338 @@
+import { isEmpty } from 'lodash';
+import Scheduler from '../scheduler';
+import { STATUS } from '../resource-request';
+import { MINUTE, SECOND } from '../../utils/constants';
+
+// TODO: Handle timeouts
+
+describe( 'Scheduler', () => {
+	const now = new Date();
+	const threeMinutesAgo = new Date( now.getTime() - ( 3 * MINUTE ) );
+	const fourMinutesAgo = new Date( now.getTime() - ( 4 * MINUTE ) );
+
+	describe( 'constructor', () => {
+		it( 'creates an array of requests', () => {
+			const scheduler = new Scheduler( () => {}, 0 );
+
+			expect( scheduler.requests ).toEqual( [] );
+		} );
+	} );
+
+	describe( 'scheduleRequest', () => {
+		it( 'creates an overdue request when no existing state exists', () => {
+			const scheduler = new Scheduler( () => {}, 0 );
+			const resourceName = 'resource1';
+
+			scheduler.scheduleRequest( resourceName, {}, {}, threeMinutesAgo );
+			const request = scheduler.requests[ 0 ];
+
+			expect( request ).not.toBe( undefined );
+			expect( request.getStatus( now ) ).toBe( STATUS.overdue );
+		} );
+
+		it( 'creates a scheduled request when state exists', () => {
+			const scheduler = new Scheduler( () => {}, 0 );
+			const resourceName = 'resource1';
+			const requirement = { freshness: 5 * MINUTE };
+			const resourceState = { lastReceived: threeMinutesAgo };
+
+			scheduler.scheduleRequest( resourceName, requirement, resourceState );
+			const request = scheduler.requests[ 0 ];
+
+			expect( request ).not.toBe( undefined );
+			expect( request.getStatus( now ) ).toBe( STATUS.scheduled );
+			expect( request.getTimeLeft( now ) ).toBe( 2 * MINUTE );
+		} );
+
+		it( 'updates an existing scheduled request with a new scheduled requirement', () => {
+			const scheduler = new Scheduler( () => {}, 0 );
+			const resourceName = 'resource1';
+			const requirement1 = { freshness: 5 * MINUTE };
+			const requirement2 = { freshness: 4 * MINUTE };
+			const requirement3 = { freshness: 2 * MINUTE };
+			const resourceState = { lastReceived: threeMinutesAgo };
+
+			scheduler.scheduleRequest( resourceName, requirement1, resourceState, now );
+			expect( scheduler.requests[ 0 ].getStatus( now ) ).toBe( STATUS.scheduled );
+			expect( scheduler.requests[ 0 ].getTimeLeft( now ) ).toBe( 2 * MINUTE );
+
+			scheduler.scheduleRequest( resourceName, requirement2, resourceState, now );
+			expect( scheduler.requests[ 0 ].getStatus( now ) ).toBe( STATUS.scheduled );
+			expect( scheduler.requests[ 0 ].getTimeLeft( now ) ).toBe( 1 * MINUTE );
+
+			scheduler.scheduleRequest( resourceName, requirement3, resourceState, now );
+			expect( scheduler.requests[ 0 ].getStatus( now ) ).toBe( STATUS.overdue );
+			expect( scheduler.requests[ 0 ].getTimeLeft( now ) ).toBe( -( 1 * MINUTE ) );
+		} );
+
+		it( 'does not add a new request when an identical previous request is already in flight', () => {
+			const scheduler = new Scheduler( () => {}, 0 );
+			const resourceName = 'resource1';
+			const requirement1 = { freshness: 5 * MINUTE };
+			const requirement2 = { freshness: 4 * MINUTE };
+			const resourceState = { lastReceived: threeMinutesAgo };
+
+			scheduler.scheduleRequest( resourceName, requirement1, resourceState, now );
+			expect( scheduler.requests.length ).toBe( 1 );
+			expect( scheduler.requests[ 0 ].getStatus( now ) ).toBe( STATUS.scheduled );
+			expect( scheduler.requests[ 0 ].getTimeLeft( now ) ).toBe( 2 * MINUTE );
+
+			scheduler.requests[ 0 ].getStatus = () => STATUS.inFlight;
+			scheduler.scheduleRequest( resourceName, requirement2, resourceState, now );
+
+			expect( scheduler.requests.length ).toBe( 1 );
+		} );
+	} );
+
+	describe( 'getScheduledRequest', () => {
+		it( 'finds a scheduled request', () => {
+			const scheduler = new Scheduler( () => {}, 0 );
+			const resourceName = 'resource1';
+			const requirement1 = { freshness: 5 * MINUTE };
+			const resourceState = { lastReceived: threeMinutesAgo };
+
+			scheduler.scheduleRequest( resourceName, requirement1, resourceState, now );
+			const request = scheduler.getScheduledRequest( resourceName );
+			expect( request.resourceName ).toBe( resourceName );
+			expect( request.getStatus() ).toBe( STATUS.scheduled );
+		} );
+	} );
+
+	describe( 'getInFlightRequests', () => {
+		it( 'finds any requests for a resource that are currently in-flight', () => {
+			const scheduler = new Scheduler( () => {}, 0 );
+			const resourceName = 'resource1';
+			const requirement1 = { freshness: 5 * MINUTE };
+			const resourceState = { lastReceived: threeMinutesAgo };
+
+			scheduler.scheduleRequest( resourceName, requirement1, resourceState, now );
+			scheduler.requests[ 0 ].getStatus = () => STATUS.inFlight;
+
+			const requests = scheduler.getInFlightRequests( resourceName );
+
+			expect( requests.length ).toBe( 1 );
+			expect( requests[ 0 ].resourceName ).toBe( resourceName );
+			expect( requests[ 0 ].getStatus() ).toBe( STATUS.inFlight );
+		} );
+	} );
+
+	describe( 'isRequestReady', () => {
+		it( 'returns false if the resource is still fresh enough', () => {
+			const scheduler = new Scheduler( () => {}, 0 );
+			const resourceName = 'resource1';
+			const requirement1 = { freshness: 5 * MINUTE };
+			const resourceState = { lastReceived: threeMinutesAgo };
+
+			scheduler.scheduleRequest( resourceName, requirement1, resourceState, now );
+			expect( scheduler.isRequestReady( scheduler.requests[ 0 ] ) ).toBeFalsy();
+		} );
+
+		it( 'returns true if the resource is not fresh enough', () => {
+			const scheduler = new Scheduler( () => {}, 0 );
+			const resourceName = 'resource1';
+			const requirement1 = { freshness: 2 * MINUTE };
+			const resourceState = { lastReceived: threeMinutesAgo };
+
+			scheduler.scheduleRequest( resourceName, requirement1, resourceState, now );
+			expect( scheduler.isRequestReady( scheduler.requests[ 0 ] ) ).toBeTruthy();
+		} );
+
+		it( 'returns true if the resource has not yet been fetched', () => {
+			const scheduler = new Scheduler( () => {}, 0 );
+			const resourceName = 'resource1';
+			const requirement1 = {};
+			const resourceState = {};
+
+			scheduler.scheduleRequest( resourceName, requirement1, resourceState, now );
+			expect( scheduler.isRequestReady( scheduler.requests[ 0 ] ) ).toBeTruthy();
+		} );
+
+		it( 'returns false if the resource status is anything but scheduled or overdue', () => {
+			const scheduler = new Scheduler( () => {}, 0 );
+			const resourceName = 'resource1';
+			const requirement1 = {};
+			const resourceState = {};
+
+			scheduler.scheduleRequest( resourceName, requirement1, resourceState, now );
+			const request = scheduler.requests[ 0 ];
+
+			request.getStatus = () => STATUS.complete;
+			expect( scheduler.isRequestReady( request ) ).toBeFalsy();
+
+			request.getStatus = () => STATUS.failed;
+			expect( scheduler.isRequestReady( request ) ).toBeFalsy();
+
+			request.getStatus = () => STATUS.inFlight;
+			expect( scheduler.isRequestReady( request ) ).toBeFalsy();
+
+			request.getStatus = () => STATUS.timedOut;
+			expect( scheduler.isRequestReady( request ) ).toBeFalsy();
+
+			request.getStatus = () => STATUS.unnecessary;
+			expect( scheduler.isRequestReady( request ) ).toBeFalsy();
+		} );
+	} );
+
+	describe( 'sendReadyRequests', () => {
+		it( 'does nothing when there are no requests in queue', () => {
+			const scheduler = new Scheduler( () => {}, 0 );
+
+			expect( isEmpty( scheduler.requests ) ).toBeTruthy();
+			scheduler.sendReadyRequests();
+			expect( isEmpty( scheduler.requests ) ).toBeTruthy();
+		} );
+
+		it( 'does nothing when there are no scheduled or overdue requests in queue', () => {
+			const scheduler = new Scheduler( () => {}, 0 );
+
+			scheduler.scheduleRequest( 'inFlightResource', {}, {}, now );
+			scheduler.requests[ 0 ].getStatus = () => STATUS.inFlight;
+
+			scheduler.scheduleRequest( 'timedOutResource', {}, {}, now );
+			scheduler.requests[ 1 ].getStatus = () => STATUS.timedOut;
+
+			scheduler.scheduleRequest( 'completeResource', {}, {}, now );
+			scheduler.requests[ 2 ].getStatus = () => STATUS.complete;
+
+			scheduler.scheduleRequest( 'failedResource', {}, {}, now );
+			scheduler.requests[ 3 ].getStatus = () => STATUS.failed;
+
+			scheduler.scheduleRequest( 'unnecessary', {}, {}, now );
+			scheduler.requests[ 4 ].getStatus = () => STATUS.unnecessary;
+
+			scheduler.sendReadyRequests( now );
+			expect( scheduler.requests.length ).toBe( 5 );
+		} );
+
+		it( 'Calls fetch with resource names', () => {
+			const fetch = jest.fn();
+			const scheduler = new Scheduler( fetch, 0 );
+
+			scheduler.scheduleRequest(
+				'resource1',
+				{ freshness: 5 * MINUTE },
+				{},
+				threeMinutesAgo
+			);
+			scheduler.scheduleRequest(
+				'resource2',
+				{ freshness: 3 * MINUTE },
+				{ lastReceived: fourMinutesAgo },
+				threeMinutesAgo
+			);
+
+			expect( scheduler.requests[ 0 ].getStatus( threeMinutesAgo ) ).toBe( STATUS.scheduled );
+			expect( scheduler.requests[ 1 ].getStatus( threeMinutesAgo ) ).toBe( STATUS.scheduled );
+
+			fetch.mockReturnValue( Promise.resolve() );
+
+			return scheduler.sendReadyRequests( now ).then( () => {
+				expect( fetch ).toHaveBeenCalledWith( [
+					scheduler.requests[ 0 ].resourceName,
+					scheduler.requests[ 1 ].resourceName
+				] );
+			} );
+		} );
+
+		it( 'calls request.requested for each ready request', () => {
+			const fetch = jest.fn();
+			const scheduler = new Scheduler( fetch, 0 );
+
+			scheduler.scheduleRequest(
+				'resource1',
+				{ freshness: 5 * MINUTE },
+				{},
+				threeMinutesAgo
+			);
+			scheduler.scheduleRequest(
+				'resource2',
+				{ freshness: 3 * MINUTE },
+				{ lastReceived: fourMinutesAgo },
+				threeMinutesAgo
+			);
+
+			expect( scheduler.requests[ 0 ].getStatus( threeMinutesAgo ) ).toBe( STATUS.scheduled );
+			expect( scheduler.requests[ 1 ].getStatus( threeMinutesAgo ) ).toBe( STATUS.scheduled );
+
+			const promise = Promise.resolve();
+			fetch.mockReturnValue( promise );
+
+			return scheduler.sendReadyRequests( now ).then( () => {
+				expect( scheduler.requests[ 0 ].getStatus( now ) ).toBe( STATUS.complete );
+				expect( scheduler.requests[ 1 ].getStatus( now ) ).toBe( STATUS.complete );
+			} );
+		} );
+	} );
+
+	describe( 'cleanUp', () => {
+		it( 'clears out completed and failed requests', () => {
+			const scheduler = new Scheduler( () => {}, 0 );
+
+			scheduler.scheduleRequest( 'scheduledResource', {}, {}, now );
+			scheduler.requests[ 0 ].getStatus = () => STATUS.scheduled;
+
+			scheduler.scheduleRequest( 'completeResource', {}, {}, now );
+			scheduler.requests[ 1 ].getStatus = () => STATUS.complete;
+
+			scheduler.scheduleRequest( 'failedResource', {}, {}, now );
+			scheduler.requests[ 2 ].getStatus = () => STATUS.failed;
+
+			expect( scheduler.requests.length ).toBe( 3 );
+
+			scheduler.cleanUp( now );
+
+			expect( scheduler.requests.length ).toBe( 1 );
+			expect( scheduler.requests[ 0 ].getStatus() ).toBe( STATUS.scheduled );
+		} );
+	} );
+
+	describe( 'resendTimeouts', () => {
+		it( 're-sends timed out requests', () => {
+			const fetch = jest.fn();
+			const scheduler = new Scheduler( fetch, 0 );
+
+			scheduler.scheduleRequest(
+				'resource1',
+				{ freshness: 5 * MINUTE, timeout: 5 * SECOND },
+				{},
+				threeMinutesAgo
+			);
+			scheduler.requests[ 0 ].getStatus = () => STATUS.timedOut;
+
+			fetch.mockReturnValue( Promise.resolve() );
+
+			return scheduler.resendTimeouts( now ).then( () => {
+				expect( fetch ).toHaveBeenCalledWith( [ scheduler.requests[ 0 ].resourceName ] );
+			} );
+		} );
+	} );
+
+	describe( 'setInterval', () => {
+		it( 'should be called by the constructor', () => {
+			const setInterval = jest.fn();
+			new Scheduler( () => {}, 1000, setInterval );
+
+			expect( setInterval ).toHaveBeenCalled();
+		} );
+
+		it( 'should provide a callback', () => {
+			let setIntervalCallback = null;
+			let setIntervalInterval = null;
+			const setInterval = ( callback, interval ) => {
+				setIntervalCallback = callback;
+				setIntervalInterval = interval;
+			};
+
+			const scheduler = new Scheduler( () => {}, 1000, setInterval );
+			scheduler.sendReadyRequests = jest.fn();
+			scheduler.resendTimeouts = jest.fn();
+			scheduler.cleanUp = jest.fn();
+			setIntervalCallback();
+
+			expect( setIntervalInterval ).toBe( 1000 );
+			expect( scheduler.sendReadyRequests ).toHaveBeenCalledTimes( 1 );
+			expect( scheduler.resendTimeouts ).toHaveBeenCalledTimes( 1 );
+			expect( scheduler.cleanUp ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+} );

--- a/packages/framework/src/client/resource-request.js
+++ b/packages/framework/src/client/resource-request.js
@@ -15,7 +15,7 @@ export const STATUS = {
 };
 
 export default class ResourceRequest {
-	constructor( resourceName, requirement, resourceState, now ) {
+	constructor( resourceName, requirement, resourceState, now = new Date() ) {
 		this.debug = debugFactory( 'fresh-data:request(' + resourceName + ')' );
 		this.resourceName = resourceName;
 		this.time = calculateRequestTime( requirement, resourceState, now );
@@ -31,7 +31,7 @@ export default class ResourceRequest {
 		}
 	}
 
-	addRequirement( requirement, resourceState, now ) {
+	addRequirement( requirement, resourceState, now = new Date() ) {
 		const status = this.getStatus( now );
 		if ( STATUS.scheduled === status || STATUS.overdue === status ) {
 			const requestTime = calculateRequestTime( requirement, resourceState, now );

--- a/packages/framework/src/client/scheduler.js
+++ b/packages/framework/src/client/scheduler.js
@@ -131,7 +131,7 @@ export default class Scheduler {
 	 */
 	isRequestReady = ( request, now = new Date() ) => {
 		const status = request.getStatus();
-		if ( STATUS.scheduled == status || STATUS.overdue == status ) {
+		if ( STATUS.scheduled === status || STATUS.overdue === status ) {
 			const timeLeft = request.getTimeLeft( now );
 			return ( timeLeft <= 0 );
 		}

--- a/packages/framework/src/client/scheduler.js
+++ b/packages/framework/src/client/scheduler.js
@@ -1,0 +1,140 @@
+import { find } from 'lodash';
+import ResourceRequest, { STATUS } from './resource-request';
+
+const DEFAULT_FETCH_INTERVAL = 5000; // Five seconds
+
+export default class Scheduler {
+	constructor(
+		fetch,
+		fetchInterval = DEFAULT_FETCH_INTERVAL,
+		setInterval = window.setInterval,
+	) {
+		this.fetch = fetch;
+		this.requests = [];
+		this.timerId = null;
+
+		if ( fetchInterval > 0 ) {
+			setInterval( () => {
+				this.cleanUp();
+				this.resendTimeouts();
+				this.sendReadyRequests();
+			}, fetchInterval );
+		}
+	}
+
+	/**
+	 * Finds a request that is either scheduled or overdue.
+	 * @param {string} resourceName The name of the resource to be read
+	 * @return {ResourceRequest} The scheduled request, or null if none found
+	 */
+	getScheduledRequest = ( resourceName ) => {
+		return find( this.requests, ( r ) => {
+			if ( resourceName === r.resourceName ) {
+				const status = r.getStatus();
+				return STATUS.scheduled === status || STATUS.overdue === status;
+			}
+			return false;
+		} );
+	}
+
+	/**
+	 * Finds requests that are in flight by resourceName
+	 * @param {string} resourceName The name of the resource to check
+	 * @return {Array} Any requests for the given resource which are currently in flight.
+	 */
+	getInFlightRequests = ( resourceName ) => {
+		return this.requests.filter( ( r ) => {
+			return ( resourceName === r.resourceName && STATUS.inFlight === r.getStatus() );
+		} );
+	}
+
+	/**
+	 * Schedule a read of a resource name according to the requirement set given.
+	 * @param {string} resourceName The name of the resource to be read
+	 * @param {Object} requirement The set of requirements (freshness, timeout)
+	 * @param {Object} resourceState The current snapshot of resource state
+	 * @param {Date} now The current time.
+	 */
+	scheduleRequest = ( resourceName, requirement, resourceState, now = new Date() ) => {
+		if ( this.getInFlightRequests( resourceName ).length > 0 ) {
+			// Do nothing, there's already a request in flight.
+			return;
+		}
+
+		const existingRequest = this.getScheduledRequest( resourceName );
+		if ( existingRequest ) {
+			existingRequest.addRequirement( requirement, resourceState, now );
+		} else {
+			this.requests.push( new ResourceRequest( resourceName, requirement, resourceState, now ) );
+		}
+	};
+
+	/**
+	 * Send a list of requests.
+	 * @param {Array} requests The list of requests to send.
+	 * @param {Date} now The current time.
+	 * @return {Promise} A promise returned from the fetch call.
+	 */
+	sendRequests = ( requests, now = new Date() ) => {
+		if ( requests.length > 0 ) {
+			const promise = this.fetch( requests.map( request => request.resourceName ) );
+
+			requests.forEach( ( request ) => {
+				request.requested( promise, now );
+			} );
+			return promise;
+		}
+		// No requests to send.
+		return Promise.resolve();
+	};
+
+	/**
+	 * Send any scheduled requests that are ready to be sent.
+	 * @param {Date} now The current time.
+	 * @return {Promise} A promise returned from the fetch call.
+	 */
+	sendReadyRequests = ( now = new Date() ) => {
+		const readyRequests = this.requests.filter( ( request ) => {
+			return this.isRequestReady( request, now );
+		} );
+		return this.sendRequests( readyRequests );
+	};
+
+	/**
+	 * Send any scheduled requests that are timed out.
+	 * @param {Date} now The current time.
+	 * @return {Promise} A promise returned from the fetch call.
+	 */
+	resendTimeouts = ( now = new Date() ) => {
+		const timedOutRequests = this.requests.filter( ( request ) => {
+			return STATUS.timedOut === request.getStatus( now );
+		} );
+		return this.sendRequests( timedOutRequests, now );
+	};
+
+	/**
+	 * Clear out completed and failed requests.
+	 * @param {Date} now The current time.
+	 */
+	cleanUp = ( now = new Date() ) => {
+		this.requests = this.requests.filter( ( request ) => {
+			const status = request.getStatus( now );
+			return STATUS.complete !== status && STATUS.failed !== status;
+		} );
+	};
+
+	/**
+	 * Checks if a request is ready.
+	 * @param {ResourceRequest} request The request to check.
+	 * @param {Date} now The current time.
+	 * @return {boolean} True if the request is ready to be sent, false otherwise.
+	 */
+	isRequestReady = ( request, now = new Date() ) => {
+		const status = request.getStatus();
+		if ( STATUS.scheduled == status || STATUS.overdue == status ) {
+			const timeLeft = request.getTimeLeft( now );
+			return ( timeLeft <= 0 );
+		}
+		return false;
+	};
+}

--- a/packages/react-provider/package-lock.json
+++ b/packages/react-provider/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fresh-data/react-provider",
-	"version": "0.6.0",
+	"version": "0.6.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {


### PR DESCRIPTION
Partially addresses #203

In step 2 of the refactor, a Scheduler class is created to manage the resource requests that come from the requirements of the components. This part is used to de-dupe resource needs, and ensure that all components are represented in the current set of requests. This is how it is no longer needed to keep track of the requirements of each component.

To Test:
1. `npm install`
2. `npm run bootstrap`
3. `npm run lint`
4. `npm run test`
