### PR TITLE
Render-based refactor: Step 3

### DIFF
--- a/packages/framework/src/client/__tests__/resource-request.spec.js
+++ b/packages/framework/src/client/__tests__/resource-request.spec.js
@@ -27,7 +27,7 @@ describe( 'ResourceRequest', () => {
 			const requirement = { freshness: 5 * MINUTE, timeout: 3 * SECOND };
 			const resourceState = { lastReceived: threeMinutesAgo };
 
-			const request = new ResourceRequest( requirement, resourceState, 'resource1', 'read', null, now );
+			const request = new ResourceRequest( requirement, resourceState, 'resource1', 'read', undefined, now );
 
 			expect( request.getStatus( now ) ).toBe( STATUS.scheduled );
 			expect( request.time ).toEqual( twoMinutesFromNow );
@@ -37,7 +37,7 @@ describe( 'ResourceRequest', () => {
 			const requirement = { timeout: 3 * SECOND };
 			const resourceState = { lastReceived: threeMinutesAgo };
 
-			const request = new ResourceRequest( requirement, resourceState, 'resource1', 'read', null, now );
+			const request = new ResourceRequest( requirement, resourceState, 'resource1', 'read', undefined, now );
 
 			expect( request.getStatus( now ) ).toBe( STATUS.unnecessary );
 			expect( request.time ).toBe( null );
@@ -49,7 +49,7 @@ describe( 'ResourceRequest', () => {
 			const requirement = { freshness: 5 * MINUTE, timeout: 3 * SECOND };
 			const resourceState = { lastReceived: threeMinutesAgo };
 
-			const request = new ResourceRequest( requirement, resourceState, 'resource1', 'read', null, now );
+			const request = new ResourceRequest( requirement, resourceState, 'resource1', 'read', undefined, now );
 
 			expect( request.getStatus( now ) ).toBe( STATUS.scheduled );
 		} );
@@ -58,7 +58,7 @@ describe( 'ResourceRequest', () => {
 			const requirement = { freshness: 5 * MINUTE, timeout: 3 * SECOND };
 			const resourceState = { lastReceived: sixMinutesAgo };
 
-			const request = new ResourceRequest( requirement, resourceState, 'resource1', 'read', null, now );
+			const request = new ResourceRequest( requirement, resourceState, 'resource1', 'read', undefined, now );
 
 			expect( request.getStatus( now ) ).toBe( STATUS.overdue );
 		} );
@@ -67,7 +67,7 @@ describe( 'ResourceRequest', () => {
 			const requirement = { freshness: 5 * MINUTE, timeout: 3 * SECOND };
 			const resourceState = { lastReceived: sixMinutesAgo };
 
-			const request = new ResourceRequest( requirement, resourceState, 'resource1', 'read', null, now );
+			const request = new ResourceRequest( requirement, resourceState, 'resource1', 'read', undefined, now );
 			request.requested( Promise.resolve(), now );
 
 			expect( request.getStatus( now ) ).toBe( STATUS.inFlight );
@@ -79,7 +79,7 @@ describe( 'ResourceRequest', () => {
 			const requirement = { freshness: 5 * MINUTE, timeout: 3 * SECOND };
 			const resourceState = { lastReceived: sixMinutesAgo };
 
-			const request = new ResourceRequest( requirement, resourceState, 'resource1', 'read', null, now );
+			const request = new ResourceRequest( requirement, resourceState, 'resource1', 'read', undefined, now );
 			request.requested( Promise.resolve(), now );
 			request.requestComplete();
 
@@ -90,7 +90,7 @@ describe( 'ResourceRequest', () => {
 			const requirement = { freshness: 5 * MINUTE, timeout: 3 * SECOND };
 			const resourceState = { lastReceived: sixMinutesAgo };
 
-			const request = new ResourceRequest( requirement, resourceState, 'resource1', 'read', null, now );
+			const request = new ResourceRequest( requirement, resourceState, 'resource1', 'read', undefined, now );
 			request.requested( Promise.resolve(), now );
 			request.requestFailed( 'error message' );
 
@@ -102,7 +102,7 @@ describe( 'ResourceRequest', () => {
 			const requirement = { freshness: 5 * MINUTE, timeout: 3 * SECOND };
 			const resourceState = { lastReceived: sixMinutesAgo };
 
-			const request = new ResourceRequest( requirement, resourceState, 'resource1', 'read', null, tenSecondsAgo );
+			const request = new ResourceRequest( requirement, resourceState, 'resource1', 'read', undefined, tenSecondsAgo );
 			request.requested( Promise.resolve(), tenSecondsAgo );
 
 			expect( request.getStatus( now ) ).toBe( STATUS.timedOut );
@@ -116,7 +116,7 @@ describe( 'ResourceRequest', () => {
 			const requirement = { freshness: 5 * MINUTE, timeout: 3 * SECOND };
 			const resourceState = { lastReceived: threeMinutesAgo };
 
-			const request = new ResourceRequest( requirement, resourceState, 'resource1', 'read', null, now );
+			const request = new ResourceRequest( requirement, resourceState, 'resource1', 'read', undefined, now );
 
 			expect( request.getStatus( now ) ).toBe( STATUS.scheduled );
 			expect( request.getTimeLeft() ).toBeLessThan( 2 * MINUTE );
@@ -126,7 +126,7 @@ describe( 'ResourceRequest', () => {
 			const requirement = { freshness: 2 * MINUTE, timeout: 3 * SECOND };
 			const resourceState = { lastReceived: threeMinutesAgo };
 
-			const request = new ResourceRequest( requirement, resourceState, 'resource1', 'read', null, now );
+			const request = new ResourceRequest( requirement, resourceState, 'resource1', 'read', undefined, now );
 
 			expect( request.getStatus( now ) ).toBe( STATUS.overdue );
 			expect( request.getTimeLeft( now ) ).toBe( -( 1 * MINUTE ) );
@@ -135,28 +135,28 @@ describe( 'ResourceRequest', () => {
 
 	describe( 'isReady', () => {
 		it( 'returns true if the scheduled request has zero time left', () => {
-			const request = new ResourceRequest( {}, {}, 'resource1', 'read', null, now );
+			const request = new ResourceRequest( {}, {}, 'resource1', 'read', undefined, now );
 			request.getTimeLeft = () => 0;
 
 			expect( request.isReady() ).toBeTruthy();
 		} );
 
 		it( 'returns true if the scheduled request has negative time left', () => {
-			const request = new ResourceRequest( {}, {}, 'resource1', 'read', null, now );
+			const request = new ResourceRequest( {}, {}, 'resource1', 'read', undefined, now );
 			request.getTimeLeft = () => -500;
 
 			expect( request.isReady() ).toBeTruthy();
 		} );
 
 		it( 'returns false if the scheduled request has time left', () => {
-			const request = new ResourceRequest( {}, {}, 'resource1', 'read', null, now );
+			const request = new ResourceRequest( {}, {}, 'resource1', 'read', undefined, now );
 			request.getTimeLeft = () => 500;
 
 			expect( request.isReady() ).toBeFalsy();
 		} );
 
 		it( 'returns false if the resource status is anything but scheduled or overdue', () => {
-			const request = new ResourceRequest( {}, {}, 'resource1', 'read', null, now );
+			const request = new ResourceRequest( {}, {}, 'resource1', 'read', undefined, now );
 
 			request.getStatus = () => STATUS.complete;
 			expect( request.isReady( request ) ).toBeFalsy();
@@ -175,27 +175,25 @@ describe( 'ResourceRequest', () => {
 		} );
 	} );
 
-	describe( 'hasData', () => {
+	describe( 'alreadyHasData', () => {
 		it( 'returns false if no data is set', () => {
 			const request1 = new ResourceRequest( {}, {}, 'resource1', 'read' );
 			const request2 = new ResourceRequest( {}, {}, 'resource1', 'read', undefined );
-			const request3 = new ResourceRequest( {}, {}, 'resource1', 'read', null );
 
-			expect( request1.hasData( { one: 1 } ) ).toBeFalsy();
-			expect( request2.hasData( { one: 1 } ) ).toBeFalsy();
-			expect( request3.hasData( { one: 1 } ) ).toBeFalsy();
+			expect( request1.alreadyHasData( { one: 1 } ) ).toBeFalsy();
+			expect( request2.alreadyHasData( { one: 1 } ) ).toBeFalsy();
 		} );
 
 		it( 'returns true if data is set', () => {
 			const request1 = new ResourceRequest( {}, {}, 'resource1', 'read', { one: 1 } );
 
-			expect( request1.hasData( { one: 1 } ) ).toBeTruthy();
+			expect( request1.alreadyHasData( { one: 1 } ) ).toBeTruthy();
 		} );
 
 		it( 'returns flase if data set is different', () => {
 			const request1 = new ResourceRequest( {}, {}, 'resource1', 'read', { one: 1 } );
 
-			expect( request1.hasData( { one: 2 } ) ).toBeFalsy();
+			expect( request1.alreadyHasData( { one: 2 } ) ).toBeFalsy();
 		} );
 	} );
 
@@ -205,11 +203,11 @@ describe( 'ResourceRequest', () => {
 			const requirement2 = { freshness: 4 * MINUTE, timeout: 3 * SECOND };
 			const resourceState = { lastReceived: threeMinutesAgo };
 
-			const request = new ResourceRequest( requirement1, resourceState, 'resource1', 'read', null, tenSecondsAgo );
+			const request = new ResourceRequest( requirement1, resourceState, 'resource1', 'read', undefined, tenSecondsAgo );
 			expect( request.getStatus( now ) ).toBe( STATUS.scheduled );
 			expect( request.getTimeLeft( now ) ).toBe( 2 * MINUTE );
 
-			expect( request.append( requirement2, resourceState, null, now ) ).toBeTruthy();
+			expect( request.append( requirement2, resourceState, undefined, now ) ).toBeTruthy();
 			expect( request.getStatus( now ) ).toBe( STATUS.scheduled );
 			expect( request.getTimeLeft( now ) ).toBe( 1 * MINUTE );
 		} );
@@ -219,11 +217,11 @@ describe( 'ResourceRequest', () => {
 			const requirement2 = { freshness: 5 * MINUTE, timeout: 3 * SECOND };
 			const resourceState = { lastReceived: threeMinutesAgo };
 
-			const request = new ResourceRequest( requirement1, resourceState, 'resource1', 'read', null, tenSecondsAgo );
+			const request = new ResourceRequest( requirement1, resourceState, 'resource1', 'read', undefined, tenSecondsAgo );
 			expect( request.getStatus( now ) ).toBe( STATUS.scheduled );
 			expect( request.getTimeLeft( now ) ).toBe( 1 * MINUTE );
 
-			expect( request.append( requirement2, resourceState, null, now ) ).toBeTruthy();
+			expect( request.append( requirement2, resourceState, undefined, now ) ).toBeTruthy();
 			expect( request.getStatus( now ) ).toBe( STATUS.scheduled );
 			expect( request.getTimeLeft( now ) ).toBe( 1 * MINUTE );
 		} );
@@ -233,10 +231,10 @@ describe( 'ResourceRequest', () => {
 			const requirement2 = { freshness: 4 * MINUTE, timeout: 3 * SECOND };
 			const resourceState = { lastReceived: threeMinutesAgo };
 
-			const request = new ResourceRequest( requirement1, resourceState, 'resource1', 'read', null, tenSecondsAgo );
+			const request = new ResourceRequest( requirement1, resourceState, 'resource1', 'read', undefined, tenSecondsAgo );
 			expect( request.getStatus( now ) ).toBe( STATUS.unnecessary );
 
-			expect( request.append( requirement2, resourceState, null, now ) ).toBeFalsy();
+			expect( request.append( requirement2, resourceState, undefined, now ) ).toBeFalsy();
 			expect( request.getStatus( now ) ).toBe( STATUS.unnecessary );
 		} );
 

--- a/packages/framework/src/client/__tests__/resource-request.spec.js
+++ b/packages/framework/src/client/__tests__/resource-request.spec.js
@@ -9,12 +9,16 @@ describe( 'ResourceRequest', () => {
 	const twoMinutesFromNow = new Date( now.getTime() + ( 2 * MINUTE ) );
 
 	describe( 'constructor', () => {
-		it( 'creates a request to be fetched immediately', () => {
+		it( 'creates a request to be requested immediately', () => {
 			const requirement = {};
 			const resourceState = {};
+			const data = {};
 
-			const request = new ResourceRequest( 'resource1', requirement, resourceState, now );
+			const request = new ResourceRequest( requirement, resourceState, 'resource1', 'operation1', data, now );
 
+			expect( request.resourceName ).toBe( 'resource1' );
+			expect( request.operation ).toBe( 'operation1' );
+			expect( request.data ).toBe( data );
 			expect( request.getStatus() ).toBe( STATUS.overdue );
 			expect( request.time ).toBe( now );
 		} );
@@ -23,7 +27,7 @@ describe( 'ResourceRequest', () => {
 			const requirement = { freshness: 5 * MINUTE, timeout: 3 * SECOND };
 			const resourceState = { lastReceived: threeMinutesAgo };
 
-			const request = new ResourceRequest( 'resource1', requirement, resourceState, now );
+			const request = new ResourceRequest( requirement, resourceState, 'resource1', 'read', null, now );
 
 			expect( request.getStatus( now ) ).toBe( STATUS.scheduled );
 			expect( request.time ).toEqual( twoMinutesFromNow );
@@ -33,7 +37,7 @@ describe( 'ResourceRequest', () => {
 			const requirement = { timeout: 3 * SECOND };
 			const resourceState = { lastReceived: threeMinutesAgo };
 
-			const request = new ResourceRequest( 'resource1', requirement, resourceState, now );
+			const request = new ResourceRequest( requirement, resourceState, 'resource1', 'read', null, now );
 
 			expect( request.getStatus( now ) ).toBe( STATUS.unnecessary );
 			expect( request.time ).toBe( null );
@@ -45,7 +49,7 @@ describe( 'ResourceRequest', () => {
 			const requirement = { freshness: 5 * MINUTE, timeout: 3 * SECOND };
 			const resourceState = { lastReceived: threeMinutesAgo };
 
-			const request = new ResourceRequest( 'resource1', requirement, resourceState, now );
+			const request = new ResourceRequest( requirement, resourceState, 'resource1', 'read', null, now );
 
 			expect( request.getStatus( now ) ).toBe( STATUS.scheduled );
 		} );
@@ -54,7 +58,7 @@ describe( 'ResourceRequest', () => {
 			const requirement = { freshness: 5 * MINUTE, timeout: 3 * SECOND };
 			const resourceState = { lastReceived: sixMinutesAgo };
 
-			const request = new ResourceRequest( 'resource1', requirement, resourceState, now );
+			const request = new ResourceRequest( requirement, resourceState, 'resource1', 'read', null, now );
 
 			expect( request.getStatus( now ) ).toBe( STATUS.overdue );
 		} );
@@ -63,7 +67,7 @@ describe( 'ResourceRequest', () => {
 			const requirement = { freshness: 5 * MINUTE, timeout: 3 * SECOND };
 			const resourceState = { lastReceived: sixMinutesAgo };
 
-			const request = new ResourceRequest( 'resource1', requirement, resourceState, now );
+			const request = new ResourceRequest( requirement, resourceState, 'resource1', 'read', null, now );
 			request.requested( Promise.resolve(), now );
 
 			expect( request.getStatus( now ) ).toBe( STATUS.inFlight );
@@ -75,7 +79,7 @@ describe( 'ResourceRequest', () => {
 			const requirement = { freshness: 5 * MINUTE, timeout: 3 * SECOND };
 			const resourceState = { lastReceived: sixMinutesAgo };
 
-			const request = new ResourceRequest( 'resource1', requirement, resourceState, now );
+			const request = new ResourceRequest( requirement, resourceState, 'resource1', 'read', null, now );
 			request.requested( Promise.resolve(), now );
 
 			return request.promise.then( () => {
@@ -87,7 +91,7 @@ describe( 'ResourceRequest', () => {
 			const requirement = { freshness: 5 * MINUTE, timeout: 3 * SECOND };
 			const resourceState = { lastReceived: sixMinutesAgo };
 
-			const request = new ResourceRequest( 'resource1', requirement, resourceState, now );
+			const request = new ResourceRequest( requirement, resourceState, 'resource1', 'read', null, now );
 			request.requested( Promise.reject( 'error message' ), now );
 
 			return request.promise.catch( () => {
@@ -100,7 +104,7 @@ describe( 'ResourceRequest', () => {
 			const requirement = { freshness: 5 * MINUTE, timeout: 3 * SECOND };
 			const resourceState = { lastReceived: sixMinutesAgo };
 
-			const request = new ResourceRequest( 'resource1', requirement, resourceState, tenSecondsAgo );
+			const request = new ResourceRequest( requirement, resourceState, 'resource1', 'read', null, tenSecondsAgo );
 			request.requested( Promise.resolve(), tenSecondsAgo );
 
 			expect( request.getStatus( now ) ).toBe( STATUS.timedOut );
@@ -114,7 +118,7 @@ describe( 'ResourceRequest', () => {
 			const requirement = { freshness: 5 * MINUTE, timeout: 3 * SECOND };
 			const resourceState = { lastReceived: threeMinutesAgo };
 
-			const request = new ResourceRequest( 'resource1', requirement, resourceState, now );
+			const request = new ResourceRequest( requirement, resourceState, 'resource1', 'read', null, now );
 
 			expect( request.getStatus( now ) ).toBe( STATUS.scheduled );
 			expect( request.getTimeLeft() ).toBeLessThan( 2 * MINUTE );
@@ -124,16 +128,82 @@ describe( 'ResourceRequest', () => {
 			const requirement = { freshness: 2 * MINUTE, timeout: 3 * SECOND };
 			const resourceState = { lastReceived: threeMinutesAgo };
 
-			const request = new ResourceRequest( 'resource1', requirement, resourceState, now );
+			const request = new ResourceRequest( requirement, resourceState, 'resource1', 'read', null, now );
 
 			expect( request.getStatus( now ) ).toBe( STATUS.overdue );
 			expect( request.getTimeLeft( now ) ).toBe( -( 1 * MINUTE ) );
 		} );
 	} );
 
+	describe( 'isReady', () => {
+		it( 'returns true if the scheduled request has zero time left', () => {
+			const request = new ResourceRequest( {}, {}, 'resource1', 'read', null, now );
+			request.getTimeLeft = () => 0;
+
+			expect( request.isReady() ).toBeTruthy();
+		} );
+
+		it( 'returns true if the scheduled request has negative time left', () => {
+			const request = new ResourceRequest( {}, {}, 'resource1', 'read', null, now );
+			request.getTimeLeft = () => -500;
+
+			expect( request.isReady() ).toBeTruthy();
+		} );
+
+		it( 'returns false if the scheduled request has time left', () => {
+			const request = new ResourceRequest( {}, {}, 'resource1', 'read', null, now );
+			request.getTimeLeft = () => 500;
+
+			expect( request.isReady() ).toBeFalsy();
+		} );
+
+		it( 'returns false if the resource status is anything but scheduled or overdue', () => {
+			const request = new ResourceRequest( {}, {}, 'resource1', 'read', null, now );
+
+			request.getStatus = () => STATUS.complete;
+			expect( request.isReady( request ) ).toBeFalsy();
+
+			request.getStatus = () => STATUS.failed;
+			expect( request.isReady( request ) ).toBeFalsy();
+
+			request.getStatus = () => STATUS.inFlight;
+			expect( request.isReady( request ) ).toBeFalsy();
+
+			request.getStatus = () => STATUS.timedOut;
+			expect( request.isReady( request ) ).toBeFalsy();
+
+			request.getStatus = () => STATUS.unnecessary;
+			expect( request.isReady( request ) ).toBeFalsy();
+		} );
+	} );
+
+	describe( 'hasData', () => {
+		it( 'returns false if no data is set', () => {
+			const request1 = new ResourceRequest( {}, {}, 'resource1', 'read' );
+			const request2 = new ResourceRequest( {}, {}, 'resource1', 'read', undefined );
+			const request3 = new ResourceRequest( {}, {}, 'resource1', 'read', null );
+
+			expect( request1.hasData( { one: 1 } ) ).toBeFalsy();
+			expect( request2.hasData( { one: 1 } ) ).toBeFalsy();
+			expect( request3.hasData( { one: 1 } ) ).toBeFalsy();
+		} );
+
+		it( 'returns true if data is set', () => {
+			const request1 = new ResourceRequest( {}, {}, 'resource1', 'read', { one: 1 } );
+
+			expect( request1.hasData( { one: 1 } ) ).toBeTruthy();
+		} );
+
+		it( 'returns flase if data set is different', () => {
+			const request1 = new ResourceRequest( {}, {}, 'resource1', 'read', { one: 1 } );
+
+			expect( request1.hasData( { one: 2 } ) ).toBeFalsy();
+		} );
+	} );
+
 	describe( 'requested', () => {
 		it( 'progresses through success flow correctly', () => {
-			const request = new ResourceRequest( 'resource1', {}, {}, tenSecondsAgo );
+			const request = new ResourceRequest( {}, {}, 'resource1', 'read', null, tenSecondsAgo );
 
 			expect( request.getStatus( now ) ).toBe( STATUS.overdue );
 
@@ -153,7 +223,7 @@ describe( 'ResourceRequest', () => {
 		} );
 
 		it( 'progresses through error flow correctly', () => {
-			const request = new ResourceRequest( 'resource1', {}, {}, tenSecondsAgo );
+			const request = new ResourceRequest( {}, {}, 'resource1', 'read', null, tenSecondsAgo );
 
 			expect( request.getStatus( now ) ).toBe( STATUS.overdue );
 
@@ -174,17 +244,17 @@ describe( 'ResourceRequest', () => {
 		} );
 	} );
 
-	describe( 'addRequirement', () => {
+	describe( 'append', () => {
 		it( 'reschedules earlier', () => {
 			const requirement1 = { freshness: 5 * MINUTE, timeout: 3 * SECOND };
 			const requirement2 = { freshness: 4 * MINUTE, timeout: 3 * SECOND };
 			const resourceState = { lastReceived: threeMinutesAgo };
 
-			const request = new ResourceRequest( 'resource1', requirement1, resourceState, tenSecondsAgo );
+			const request = new ResourceRequest( requirement1, resourceState, 'resource1', 'read', null, tenSecondsAgo );
 			expect( request.getStatus( now ) ).toBe( STATUS.scheduled );
 			expect( request.getTimeLeft( now ) ).toBe( 2 * MINUTE );
 
-			expect( request.addRequirement( requirement2, resourceState, now ) ).toBeTruthy();
+			expect( request.append( requirement2, resourceState, null, now ) ).toBeTruthy();
 			expect( request.getStatus( now ) ).toBe( STATUS.scheduled );
 			expect( request.getTimeLeft( now ) ).toBe( 1 * MINUTE );
 		} );
@@ -194,11 +264,11 @@ describe( 'ResourceRequest', () => {
 			const requirement2 = { freshness: 5 * MINUTE, timeout: 3 * SECOND };
 			const resourceState = { lastReceived: threeMinutesAgo };
 
-			const request = new ResourceRequest( 'resource1', requirement1, resourceState, tenSecondsAgo );
+			const request = new ResourceRequest( requirement1, resourceState, 'resource1', 'read', null, tenSecondsAgo );
 			expect( request.getStatus( now ) ).toBe( STATUS.scheduled );
 			expect( request.getTimeLeft( now ) ).toBe( 1 * MINUTE );
 
-			expect( request.addRequirement( requirement2, resourceState, now ) ).toBeTruthy();
+			expect( request.append( requirement2, resourceState, null, now ) ).toBeTruthy();
 			expect( request.getStatus( now ) ).toBe( STATUS.scheduled );
 			expect( request.getTimeLeft( now ) ).toBe( 1 * MINUTE );
 		} );
@@ -208,11 +278,27 @@ describe( 'ResourceRequest', () => {
 			const requirement2 = { freshness: 4 * MINUTE, timeout: 3 * SECOND };
 			const resourceState = { lastReceived: threeMinutesAgo };
 
-			const request = new ResourceRequest( 'resource1', requirement1, resourceState, tenSecondsAgo );
+			const request = new ResourceRequest( requirement1, resourceState, 'resource1', 'read', null, tenSecondsAgo );
 			expect( request.getStatus( now ) ).toBe( STATUS.unnecessary );
 
-			expect( request.addRequirement( requirement2, resourceState, now ) ).toBeFalsy();
+			expect( request.append( requirement2, resourceState, null, now ) ).toBeFalsy();
 			expect( request.getStatus( now ) ).toBe( STATUS.unnecessary );
+		} );
+
+		it( 'adds data to request', () => {
+			const request = new ResourceRequest( {}, {}, 'resource1', 'update', { field1: 'value1' }, now );
+			expect( request.data ).toEqual( { field1: 'value1' } );
+
+			expect( request.append( {}, {}, { field2: 'value2' }, now ) ).toBeTruthy();
+			expect( request.data ).toEqual( { field1: 'value1', field2: 'value2' } );
+		} );
+
+		it( 'overwrites existing data in request', () => {
+			const request = new ResourceRequest( {}, {}, 'resource1', 'update', { field1: 'value1', field2: 'value2' }, now );
+			expect( request.data ).toEqual( { field1: 'value1', field2: 'value2' } );
+
+			expect( request.append( {}, {}, { field2: 'abc' }, now ) ).toBeTruthy();
+			expect( request.data ).toEqual( { field1: 'value1', field2: 'abc' } );
 		} );
 	} );
 } );

--- a/packages/framework/src/client/__tests__/scheduler.spec.js
+++ b/packages/framework/src/client/__tests__/scheduler.spec.js
@@ -673,48 +673,6 @@ describe( 'Scheduler', () => {
 				expect( scheduler.requests[ 1 ].getStatus( now ) ).toBe( STATUS.complete );
 			} );
 		} );
-	} );
-
-	describe( 'cleanUp', () => {
-		it( 'does not clear scheduled requests', () => {
-			const operations = {
-				read: jest.fn(),
-			};
-			const scheduler = new Scheduler( operations, () => {}, () => {} );
-
-			scheduler.scheduleRequest( {}, {}, 'scheduledResource', 'read', undefined, now );
-			scheduler.requests[ 0 ].getStatus = () => STATUS.scheduled;
-
-			expect( scheduler.requests.length ).toBe( 1 );
-
-			scheduler.cleanUp();
-
-			expect( scheduler.requests.length ).toBe( 1 );
-			expect( scheduler.requests[ 0 ].getStatus() ).toBe( STATUS.scheduled );
-		} );
-
-		it( 'clears out completed and failed requests', () => {
-			const operations = {
-				read: jest.fn(),
-			};
-			const scheduler = new Scheduler( operations, () => {}, () => {} );
-
-			scheduler.scheduleRequest( {}, {}, 'scheduledResource', 'read', undefined, now );
-			scheduler.requests[ 0 ].getStatus = () => STATUS.scheduled;
-
-			scheduler.scheduleRequest( {}, {}, 'completeResource', 'read', undefined, now );
-			scheduler.requests[ 1 ].getStatus = () => STATUS.complete;
-
-			scheduler.scheduleRequest( {}, {}, 'failedResource', 'read', undefined, now );
-			scheduler.requests[ 2 ].getStatus = () => STATUS.failed;
-
-			expect( scheduler.requests.length ).toBe( 3 );
-
-			scheduler.cleanUp();
-
-			expect( scheduler.requests.length ).toBe( 1 );
-			expect( scheduler.requests[ 0 ].getStatus() ).toBe( STATUS.scheduled );
-		} );
 
 		it( 'combines data from multiple requests into one operation call', () => {
 			const operations = {
@@ -852,6 +810,48 @@ describe( 'Scheduler', () => {
 					{ resource2: { data: { two: 'two' } } },
 				);
 			} );
+		} );
+	} );
+
+	describe( 'cleanUp', () => {
+		it( 'does not clear scheduled requests', () => {
+			const operations = {
+				read: jest.fn(),
+			};
+			const scheduler = new Scheduler( operations, () => {}, () => {} );
+
+			scheduler.scheduleRequest( {}, {}, 'scheduledResource', 'read', undefined, now );
+			scheduler.requests[ 0 ].getStatus = () => STATUS.scheduled;
+
+			expect( scheduler.requests.length ).toBe( 1 );
+
+			scheduler.cleanUp();
+
+			expect( scheduler.requests.length ).toBe( 1 );
+			expect( scheduler.requests[ 0 ].getStatus() ).toBe( STATUS.scheduled );
+		} );
+
+		it( 'clears out completed and failed requests', () => {
+			const operations = {
+				read: jest.fn(),
+			};
+			const scheduler = new Scheduler( operations, () => {}, () => {} );
+
+			scheduler.scheduleRequest( {}, {}, 'scheduledResource', 'read', undefined, now );
+			scheduler.requests[ 0 ].getStatus = () => STATUS.scheduled;
+
+			scheduler.scheduleRequest( {}, {}, 'completeResource', 'read', undefined, now );
+			scheduler.requests[ 1 ].getStatus = () => STATUS.complete;
+
+			scheduler.scheduleRequest( {}, {}, 'failedResource', 'read', undefined, now );
+			scheduler.requests[ 2 ].getStatus = () => STATUS.failed;
+
+			expect( scheduler.requests.length ).toBe( 3 );
+
+			scheduler.cleanUp();
+
+			expect( scheduler.requests.length ).toBe( 1 );
+			expect( scheduler.requests[ 0 ].getStatus() ).toBe( STATUS.scheduled );
 		} );
 	} );
 

--- a/packages/framework/src/client/__tests__/scheduler.spec.js
+++ b/packages/framework/src/client/__tests__/scheduler.spec.js
@@ -101,13 +101,8 @@ describe( 'sendOperation', () => {
 		expect( request1b.timeRequested ).toBe( now );
 		expect( request2.timeRequested ).toBe( now );
 
-		return promise.then( ( response ) => {
+		return promise.then( () => {
 			expect( operation ).toHaveBeenCalledWith( [ 'resource1', 'resource2' ], undefined );
-
-			expect( response ).toEqual( [ {
-				resource1: { data: 1 },
-				resource2: { data: 2 },
-			} ] );
 
 			expect( dataReceived ).toHaveBeenCalledWith( {
 				resource1: { data: 1 },
@@ -145,7 +140,7 @@ describe( 'sendOperation', () => {
 		expect( request1b.timeRequested ).toBe( now );
 		expect( request2.timeRequested ).toBe( now );
 
-		return promise.then( ( response ) => {
+		return promise.then( () => {
 			expect( operation ).toHaveBeenCalledWith(
 				[ 'resource1', 'resource2' ],
 				{
@@ -153,11 +148,6 @@ describe( 'sendOperation', () => {
 					resource2: { two: 2 }
 				}
 			);
-
-			expect( response ).toEqual( [ {
-				resource1: { data: { oneA: 1, oneB: 1 } },
-				resource2: { data: { two: 2 } },
-			} ] );
 
 			expect( dataReceived ).toHaveBeenCalledWith( {
 				resource1: { data: { oneA: 1, oneB: 1 } },

--- a/packages/framework/src/client/__tests__/scheduler.spec.js
+++ b/packages/framework/src/client/__tests__/scheduler.spec.js
@@ -1,6 +1,4 @@
-import { isEmpty } from 'lodash';
 import Scheduler, {
-	getRequestsByOperation,
 	combineRequestData,
 	sendOperation
 } from '../scheduler';

--- a/packages/framework/src/client/__tests__/scheduler.spec.js
+++ b/packages/framework/src/client/__tests__/scheduler.spec.js
@@ -9,28 +9,6 @@ import { MINUTE, SECOND } from '../../utils/constants';
 
 // TODO: Handle timeouts
 
-describe( 'getRequestsByOperation', () => {
-	const now = new Date();
-
-	it( 'returns an empty object when no requests are given', () => {
-		const requestsByOperation = getRequestsByOperation( [] );
-		expect( isEmpty( requestsByOperation ) ).toBeTruthy();
-	} );
-
-	it( 'returns an object with requests sorted by operation', () => {
-		const read1 = new ResourceRequest( {}, {}, 'resource1', 'read', { one: 1 }, now );
-		const read2 = new ResourceRequest( {}, {}, 'resource2', 'read', { two: 2 }, now );
-		const write1 = new ResourceRequest( {}, {}, 'resource1', 'write', { one: 1 }, now );
-		const write2 = new ResourceRequest( {}, {}, 'resource2', 'write', { two: 2 }, now );
-
-		const requestsByOperation = getRequestsByOperation( [ read1, read2, write1, write2 ] );
-
-		expect( Object.keys( requestsByOperation ).length ).toBe( 2 );
-		expect( requestsByOperation.read ).toEqual( [ read1, read2 ] );
-		expect( requestsByOperation.write ).toEqual( [ write1, write2 ] );
-	} );
-} );
-
 describe( 'combineRequestData', () => {
 	const now = new Date();
 

--- a/packages/framework/src/client/__tests__/scheduler.spec.js
+++ b/packages/framework/src/client/__tests__/scheduler.spec.js
@@ -1,9 +1,152 @@
 import { isEmpty } from 'lodash';
-import Scheduler from '../scheduler';
+import Scheduler, {
+	getRequestsByOperation,
+	combineRequestData,
+	sendOperation
+} from '../scheduler';
 import ResourceRequest, { STATUS } from '../resource-request';
 import { MINUTE, SECOND } from '../../utils/constants';
 
 // TODO: Handle timeouts
+
+describe( 'getRequestsByOperation', () => {
+	const now = new Date();
+
+	it( 'returns an empty object when no requests are given', () => {
+		const requestsByOperation = getRequestsByOperation( [] );
+		expect( isEmpty( requestsByOperation ) ).toBeTruthy();
+	} );
+
+	it( 'returns an object with requests sorted by operation', () => {
+		const read1 = new ResourceRequest( {}, {}, 'resource1', 'read', { one: 1 }, now );
+		const read2 = new ResourceRequest( {}, {}, 'resource2', 'read', { two: 2 }, now );
+		const write1 = new ResourceRequest( {}, {}, 'resource1', 'write', { one: 1 }, now );
+		const write2 = new ResourceRequest( {}, {}, 'resource2', 'write', { two: 2 }, now );
+
+		const requestsByOperation = getRequestsByOperation( [ read1, read2, write1, write2 ] );
+
+		expect( Object.keys( requestsByOperation ).length ).toBe( 2 );
+		expect( requestsByOperation.read ).toEqual( [ read1, read2 ] );
+		expect( requestsByOperation.write ).toEqual( [ write1, write2 ] );
+	} );
+} );
+
+describe( 'combineRequestData', () => {
+	const now = new Date();
+
+	it( 'should pass through single sets of data for requests', () => {
+		const request1 = new ResourceRequest( {}, {}, 'resource1', 'write', { one: 1 }, now );
+		const request2 = new ResourceRequest( {}, {}, 'resource2', 'write', { two: 2 }, now );
+
+		const data = combineRequestData( [ request1, request2 ] );
+
+		expect( Object.keys( data ).length ).toBe( 2 );
+		expect( data.resource1 ).toEqual( { one: 1 } );
+		expect( data.resource2 ).toEqual( { two: 2 } );
+	} );
+
+	it( 'should combine multiple sets of data for requests', () => {
+		const request1a = new ResourceRequest( {}, {}, 'resource1', 'write', { oneA: 1 }, now );
+		const request1b = new ResourceRequest( {}, {}, 'resource1', 'write', { oneB: 1 }, now );
+		const request2 = new ResourceRequest( {}, {}, 'resource2', 'write', { two: 2 }, now );
+
+		const data = combineRequestData( [ request1a, request1b, request2 ] );
+
+		expect( Object.keys( data ).length ).toBe( 2 );
+		expect( data.resource1 ).toEqual( { oneA: 1, oneB: 1 } );
+		expect( data.resource2 ).toEqual( { two: 2 } );
+	} );
+
+	it( 'should handle requests with no data', () => {
+		const request1a = new ResourceRequest( {}, {}, 'resource1', 'read', undefined, now );
+		const request1b = new ResourceRequest( {}, {}, 'resource1', 'read', null, now );
+
+		const data = combineRequestData( [ request1a, request1b ] );
+
+		expect( data ).toBeFalsy();
+	} );
+} );
+
+describe( 'sendOperation', () => {
+	const now = new Date();
+	const oneSecondAgo = new Date( now.getTime() - ( 1 * SECOND ) );
+
+	it ( 'should send an operation without data', () => {
+		const request1a = new ResourceRequest( {}, {}, 'resource1', 'read', undefined, oneSecondAgo );
+		const request1b = new ResourceRequest( {}, {}, 'resource1', 'read', undefined, oneSecondAgo );
+		const request2 = new ResourceRequest( {}, {}, 'resource2', 'read', undefined, oneSecondAgo );
+		const operation = jest.fn();
+		operation.mockReturnValue( { response: true } );
+
+		const promise = sendOperation( operation, [ request1a, request1b, request2 ], now );
+
+		expect( request1a.promise ).toBe( promise );
+		expect( request1a.timeRequested ).toBe( now );
+		expect( request1b.promise ).toBe( promise );
+		expect( request1b.timeRequested ).toBe( now );
+		expect( request2.promise ).toBe( promise );
+		expect( request2.timeRequested ).toBe( now );
+
+		return promise.then( ( response ) => {
+			expect( operation ).toHaveBeenCalledWith( [ 'resource1', 'resource2' ], undefined );
+
+			expect( response ).toEqual( { response: true } );
+
+			expect( request1a.getStatus() ).toBe( STATUS.complete );
+			expect( request1a.promise ).toBeFalsy();
+			expect( request1a.timeCompleted.getTime() ).toBeGreaterThan( now.getTime() );
+
+			expect( request1b.getStatus() ).toBe( STATUS.complete );
+			expect( request1b.promise ).toBeFalsy();
+			expect( request1b.timeCompleted.getTime() ).toBeGreaterThan( now.getTime() );
+
+			expect( request2.getStatus() ).toBe( STATUS.complete );
+			expect( request2.promise ).toBeFalsy();
+			expect( request2.timeCompleted.getTime() ).toBeGreaterThan( now.getTime() );
+		} );
+	} );
+
+	it ( 'should send an operation with data', () => {
+		const request1a = new ResourceRequest( {}, {}, 'resource1', 'write', { oneA: 1 }, oneSecondAgo );
+		const request1b = new ResourceRequest( {}, {}, 'resource1', 'write', { oneB: 1 }, oneSecondAgo );
+		const request2 = new ResourceRequest( {}, {}, 'resource2', 'write', { two: 2 }, oneSecondAgo );
+		const operation = jest.fn();
+		operation.mockReturnValue( { response: true } );
+
+		const promise = sendOperation( operation, [ request1a, request1b, request2 ], now );
+
+		expect( request1a.promise ).toBe( promise );
+		expect( request1a.timeRequested ).toBe( now );
+		expect( request1b.promise ).toBe( promise );
+		expect( request1b.timeRequested ).toBe( now );
+		expect( request2.promise ).toBe( promise );
+		expect( request2.timeRequested ).toBe( now );
+
+		return promise.then( ( response ) => {
+			expect( operation ).toHaveBeenCalledWith(
+				[ 'resource1', 'resource2' ],
+				{
+					resource1: { oneA: 1, oneB: 1 },
+					resource2: { two: 2 }
+				}
+			);
+
+			expect( response ).toEqual( { response: true } );
+
+			expect( request1a.getStatus() ).toBe( STATUS.complete );
+			expect( request1a.promise ).toBeFalsy();
+			expect( request1a.timeCompleted.getTime() ).toBeGreaterThan( now.getTime() );
+
+			expect( request1b.getStatus() ).toBe( STATUS.complete );
+			expect( request1b.promise ).toBeFalsy();
+			expect( request1b.timeCompleted.getTime() ).toBeGreaterThan( now.getTime() );
+
+			expect( request2.getStatus() ).toBe( STATUS.complete );
+			expect( request2.promise ).toBeFalsy();
+			expect( request2.timeCompleted.getTime() ).toBeGreaterThan( now.getTime() );
+		} );
+	} );
+} );
 
 describe( 'Scheduler', () => {
 	const now = new Date();
@@ -12,7 +155,7 @@ describe( 'Scheduler', () => {
 
 	describe( 'constructor', () => {
 		it( 'creates an array of requests', () => {
-			const scheduler = new Scheduler( () => {}, () => {}, () => {} );
+			const scheduler = new Scheduler( {}, () => {}, () => {} );
 
 			expect( scheduler.requests ).toEqual( [] );
 		} );
@@ -20,7 +163,7 @@ describe( 'Scheduler', () => {
 		it( 'initializes timeout variables', () => {
 			const setTimeout = () => {};
 			const clearTimeout = () => {};
-			const scheduler = new Scheduler( () => {}, setTimeout, clearTimeout );
+			const scheduler = new Scheduler( {}, setTimeout, clearTimeout );
 
 			expect( scheduler.setTimeout ).toBe( setTimeout );
 			expect( scheduler.clearTimeout ).toBe( clearTimeout );
@@ -28,7 +171,7 @@ describe( 'Scheduler', () => {
 		} );
 
 		it( 'defaults to window.setTimeout and window.clearTimeout', () => {
-			const scheduler = new Scheduler( () => {} );
+			const scheduler = new Scheduler( {} );
 
 			expect( scheduler.setTimeout ).toBe( window.setTimeout );
 			expect( scheduler.clearTimeout ).toBe( window.clearTimeout );
@@ -37,48 +180,87 @@ describe( 'Scheduler', () => {
 
 	describe( 'getNextRequestDelay', () => {
 		it( 'returns null when no requests are scheduled/overdue', () => {
-			const scheduler = new Scheduler( () => {}, () => {}, () => {} );
+			const operations = {
+				read: jest.fn(),
+			};
+			const scheduler = new Scheduler( operations, () => {}, () => {} );
 
 			expect( scheduler.getNextRequestDelay() ).toBeNull();
 
-			scheduler.scheduleRequest( 'completeResource', {}, {}, now );
+			scheduler.scheduleRequest( {}, {}, 'completeResource', 'read', null, now );
 			scheduler.requests[ 0 ].getStatus = () => STATUS.complete;
 
 			expect( scheduler.getNextRequestDelay( now ) ).toBeNull();
 		} );
 
 		it( 'returns zero when a request is overdue', () => {
-			const scheduler = new Scheduler( () => {}, () => {}, () => {} );
+			const operations = {
+				read: jest.fn(),
+			};
+			const scheduler = new Scheduler( operations, () => {}, () => {} );
 
-			scheduler.scheduleRequest( 'resource1', {}, {}, threeMinutesAgo );
+			scheduler.scheduleRequest( {}, {}, 'resource1', 'read', null, threeMinutesAgo );
 
 			expect( scheduler.getNextRequestDelay( now ) ).toBe( 0 );
 		} );
 
 		it( 'returns a positive number when a request is scheduled', () => {
-			const scheduler = new Scheduler( () => {}, () => {}, () => {} );
+			const operations = {
+				read: jest.fn(),
+			};
+			const scheduler = new Scheduler( operations, () => {}, () => {} );
 
-			scheduler.scheduleRequest( 'resource1', { freshness: 5 * MINUTE }, { lastReceived: threeMinutesAgo }, now );
+			scheduler.scheduleRequest(
+				{ freshness: 5 * MINUTE },
+				{ lastReceived: threeMinutesAgo },
+				'resource1',
+				null,
+				now
+			);
 
 			expect( scheduler.getNextRequestDelay( now ) / MINUTE ).toBeCloseTo( 2, 2 );
 		} );
 
 		it( 'returns zero when a new request is scheduled that is immediately due', () => {
-			const scheduler = new Scheduler( () => {}, () => {}, () => {} );
+			const operations = {
+				read: jest.fn(),
+			};
+			const scheduler = new Scheduler( operations, () => {}, () => {} );
 
-			scheduler.scheduleRequest( 'resource1', { freshness: 5 * MINUTE }, { lastReceived: threeMinutesAgo }, now );
-			scheduler.scheduleRequest( 'resource1', {}, {}, now );
+			scheduler.scheduleRequest(
+				{ freshness: 5 * MINUTE },
+				{ lastReceived: threeMinutesAgo },
+				'resource1',
+				null,
+				now
+			);
+			scheduler.scheduleRequest( {}, {}, 'resource1', null, now );
 
 			expect( scheduler.getNextRequestDelay( now ) ).toBe( 0 );
 		} );
 
 		it( 'returns the same number when a new request that is scheduled later is added', () => {
-			const scheduler = new Scheduler( () => {}, () => {}, () => {} );
+			const operations = {
+				read: jest.fn(),
+			};
+			const scheduler = new Scheduler( operations, () => {}, () => {} );
 
-			scheduler.scheduleRequest( 'resource1', { freshness: 5 * MINUTE }, { lastReceived: threeMinutesAgo }, now );
+			scheduler.scheduleRequest(
+				{ freshness: 5 * MINUTE },
+				{ lastReceived: threeMinutesAgo },
+				'resource1',
+				null,
+				now
+			);
 			const delayBefore = scheduler.getNextRequestDelay( now );
 
-			scheduler.scheduleRequest( 'resource1', { freshness: 30 * MINUTE }, { lastReceived: fourMinutesAgo }, now );
+			scheduler.scheduleRequest(
+				{ freshness: 30 * MINUTE },
+				{ lastReceived: fourMinutesAgo },
+				'resource1',
+				null,
+				now
+			);
 			const delayAfter = scheduler.getNextRequestDelay( now );
 
 			expect( delayAfter ).toBe( delayBefore );
@@ -88,7 +270,7 @@ describe( 'Scheduler', () => {
 	describe( 'updateDelay', () => {
 		it( 'Does not stop or set timeout when no requests are scheduled/overdue', () => {
 			const setTimeout = jest.fn();
-			const scheduler = new Scheduler( () => {}, setTimeout, () => {} );
+			const scheduler = new Scheduler( {}, setTimeout, () => {} );
 			scheduler.stop = jest.fn();
 
 			scheduler.updateDelay();
@@ -99,10 +281,10 @@ describe( 'Scheduler', () => {
 
 		it( 'Sets timeout when a request is scheduled', () => {
 			const setTimeout = jest.fn();
-			const scheduler = new Scheduler( () => {}, setTimeout, () => {} );
+			const scheduler = new Scheduler( {}, setTimeout, () => {} );
 
 			scheduler.requests.push(
-				new ResourceRequest( 'resource1', { freshness: 5 * MINUTE }, { lastReceived: threeMinutesAgo }, now )
+				new ResourceRequest( { freshness: 5 * MINUTE }, { lastReceived: threeMinutesAgo }, 'resource1', null, now )
 			);
 			scheduler.updateDelay( now );
 
@@ -113,10 +295,10 @@ describe( 'Scheduler', () => {
 
 		it( 'Sets zero timeout when a request is overdue', () => {
 			const setTimeout = jest.fn();
-			const scheduler = new Scheduler( () => {}, setTimeout, () => {} );
+			const scheduler = new Scheduler( {}, setTimeout, () => {} );
 
 			scheduler.requests.push(
-				new ResourceRequest( 'resource1', { freshness: 2 * MINUTE }, { lastReceived: threeMinutesAgo }, now )
+				new ResourceRequest( { freshness: 2 * MINUTE }, { lastReceived: threeMinutesAgo }, 'resource1', null, now )
 			);
 			scheduler.updateDelay( now );
 
@@ -127,17 +309,17 @@ describe( 'Scheduler', () => {
 
 		it( 'Starts a new timeout when a newer request is scheduled', () => {
 			const setTimeout = jest.fn();
-			const scheduler = new Scheduler( () => {}, setTimeout, () => {} );
+			const scheduler = new Scheduler( {}, setTimeout, () => {} );
 
 			scheduler.requests.push(
-				new ResourceRequest( 'resource1', { freshness: 5 * MINUTE }, { lastReceived: threeMinutesAgo }, now )
+				new ResourceRequest( { freshness: 5 * MINUTE }, { lastReceived: threeMinutesAgo }, 'resource1', null, now )
 			);
 			scheduler.updateDelay( now );
 
 			expect( setTimeout ).toHaveBeenCalledTimes( 1 );
 
 			scheduler.requests.push(
-				new ResourceRequest( 'resource1', { freshness: 4 * MINUTE }, { lastReceived: threeMinutesAgo }, now )
+				new ResourceRequest( { freshness: 4 * MINUTE }, { lastReceived: threeMinutesAgo }, 'resource1', null, now )
 			);
 			scheduler.updateDelay( now );
 
@@ -149,17 +331,17 @@ describe( 'Scheduler', () => {
 
 		it( 'Starts a new zero timeout when a immediately due request is scheduled', () => {
 			const setTimeout = jest.fn();
-			const scheduler = new Scheduler( () => {}, setTimeout, () => {} );
+			const scheduler = new Scheduler( {}, setTimeout, () => {} );
 
 			scheduler.requests.push(
-				new ResourceRequest( 'resource1', { freshness: 5 * MINUTE }, { lastReceived: threeMinutesAgo }, now )
+				new ResourceRequest( { freshness: 5 * MINUTE }, { lastReceived: threeMinutesAgo }, 'resource1', null, now )
 			);
 			scheduler.updateDelay( now );
 
 			expect( setTimeout ).toHaveBeenCalledTimes( 1 );
 
 			scheduler.requests.push(
-				new ResourceRequest( 'resource2', {}, {}, now )
+				new ResourceRequest(  {}, {}, 'resource2', null, now )
 			);
 			scheduler.updateDelay( now );
 
@@ -171,10 +353,10 @@ describe( 'Scheduler', () => {
 
 		it( 'Does not start a new one if there are no longer any requests scheduled/overdue', () => {
 			const setTimeout = jest.fn();
-			const scheduler = new Scheduler( () => {}, setTimeout, () => {} );
+			const scheduler = new Scheduler( {}, setTimeout, () => {} );
 
 			scheduler.requests.push(
-				new ResourceRequest( 'resource1', { freshness: 5 * MINUTE }, { lastReceived: fourMinutesAgo }, threeMinutesAgo )
+				new ResourceRequest( { freshness: 5 * MINUTE }, { lastReceived: fourMinutesAgo }, 'resource1', null, threeMinutesAgo )
 			);
 			scheduler.updateDelay( threeMinutesAgo );
 
@@ -191,7 +373,7 @@ describe( 'Scheduler', () => {
 		it( 'Does nothing when no timer is set', () => {
 			const setTimeout = () => 123;
 			const clearTimeout = jest.fn();
-			const scheduler = new Scheduler( () => {}, setTimeout, clearTimeout );
+			const scheduler = new Scheduler( {}, setTimeout, clearTimeout );
 
 			scheduler.stop();
 
@@ -201,10 +383,10 @@ describe( 'Scheduler', () => {
 		it( 'Stops the timer when it is set', () => {
 			const setTimeout = () => 123;
 			const clearTimeout = jest.fn();
-			const scheduler = new Scheduler( () => {}, setTimeout, clearTimeout );
+			const scheduler = new Scheduler( {}, setTimeout, clearTimeout );
 
 			scheduler.requests.push(
-				new ResourceRequest( 'resource1', { freshness: 5 * MINUTE }, { lastReceived: threeMinutesAgo }, now )
+				new ResourceRequest( { freshness: 5 * MINUTE }, { lastReceived: threeMinutesAgo }, 'resource1', null, now )
 			);
 			scheduler.updateDelay( now );
 
@@ -216,11 +398,24 @@ describe( 'Scheduler', () => {
 	} );
 
 	describe( 'scheduleRequest', () => {
-		it( 'creates an overdue request when no existing state exists', () => {
-			const scheduler = new Scheduler( () => {}, () => {}, () => {} );
-			const resourceName = 'resource1';
+		it( 'uses read operation by default', () => {
+			const operations = {
+				read: jest.fn(),
+			};
+			const scheduler = new Scheduler( operations, () => {}, () => {} );
 
-			scheduler.scheduleRequest( resourceName, {}, {}, threeMinutesAgo );
+			scheduler.scheduleRequest( {}, {}, 'resource1' );
+
+			expect( scheduler.requests[ 0 ].operation ).toBe( 'read' );
+		} );
+
+		it( 'creates an overdue request when no existing state exists', () => {
+			const operations = {
+				read: jest.fn(),
+			};
+			const scheduler = new Scheduler( operations, () => {}, () => {} );
+
+			scheduler.scheduleRequest( {}, {}, 'resource1', 'read', null, threeMinutesAgo );
 			const request = scheduler.requests[ 0 ];
 
 			expect( request ).not.toBe( undefined );
@@ -228,12 +423,14 @@ describe( 'Scheduler', () => {
 		} );
 
 		it( 'creates a scheduled request when state exists', () => {
-			const scheduler = new Scheduler( () => {}, () => {}, () => {} );
-			const resourceName = 'resource1';
+			const operations = {
+				read: jest.fn(),
+			};
+			const scheduler = new Scheduler( operations, () => {}, () => {} );
 			const requirement = { freshness: 5 * MINUTE };
 			const resourceState = { lastReceived: threeMinutesAgo };
 
-			scheduler.scheduleRequest( resourceName, requirement, resourceState );
+			scheduler.scheduleRequest( requirement, resourceState, 'resource1', 'read', now );
 			const request = scheduler.requests[ 0 ];
 
 			expect( request ).not.toBe( undefined );
@@ -242,40 +439,44 @@ describe( 'Scheduler', () => {
 		} );
 
 		it( 'updates an existing scheduled request with a new scheduled requirement', () => {
-			const scheduler = new Scheduler( () => {}, () => {}, () => {} );
-			const resourceName = 'resource1';
+			const operations = {
+				read: jest.fn(),
+			};
+			const scheduler = new Scheduler( operations, () => {}, () => {} );
 			const requirement1 = { freshness: 5 * MINUTE };
 			const requirement2 = { freshness: 4 * MINUTE };
 			const requirement3 = { freshness: 2 * MINUTE };
 			const resourceState = { lastReceived: threeMinutesAgo };
 
-			scheduler.scheduleRequest( resourceName, requirement1, resourceState, now );
+			scheduler.scheduleRequest( requirement1, resourceState, 'resource1', 'read', null, now );
 			expect( scheduler.requests[ 0 ].getStatus( now ) ).toBe( STATUS.scheduled );
 			expect( scheduler.requests[ 0 ].getTimeLeft( now ) ).toBe( 2 * MINUTE );
 
-			scheduler.scheduleRequest( resourceName, requirement2, resourceState, now );
+			scheduler.scheduleRequest( requirement2, resourceState, 'resource1', 'read', null, now );
 			expect( scheduler.requests[ 0 ].getStatus( now ) ).toBe( STATUS.scheduled );
 			expect( scheduler.requests[ 0 ].getTimeLeft( now ) ).toBe( 1 * MINUTE );
 
-			scheduler.scheduleRequest( resourceName, requirement3, resourceState, now );
+			scheduler.scheduleRequest( requirement3, resourceState, 'resource1', 'read', null, now );
 			expect( scheduler.requests[ 0 ].getStatus( now ) ).toBe( STATUS.overdue );
 			expect( scheduler.requests[ 0 ].getTimeLeft( now ) ).toBe( -( 1 * MINUTE ) );
 		} );
 
 		it( 'does not add a new request when an identical previous request is already in flight', () => {
-			const scheduler = new Scheduler( () => {}, () => {}, () => {} );
-			const resourceName = 'resource1';
+			const operations = {
+				read: jest.fn(),
+			};
+			const scheduler = new Scheduler( operations, () => {}, () => {} );
 			const requirement1 = { freshness: 5 * MINUTE };
 			const requirement2 = { freshness: 4 * MINUTE };
 			const resourceState = { lastReceived: threeMinutesAgo };
 
-			scheduler.scheduleRequest( resourceName, requirement1, resourceState, now );
+			scheduler.scheduleRequest( requirement1, resourceState, 'resource1', 'read', null, now );
 			expect( scheduler.requests.length ).toBe( 1 );
 			expect( scheduler.requests[ 0 ].getStatus( now ) ).toBe( STATUS.scheduled );
 			expect( scheduler.requests[ 0 ].getTimeLeft( now ) ).toBe( 2 * MINUTE );
 
 			scheduler.requests[ 0 ].getStatus = () => STATUS.inFlight;
-			scheduler.scheduleRequest( resourceName, requirement2, resourceState, now );
+			scheduler.scheduleRequest( requirement2, resourceState, 'resource1', 'read', null, now );
 
 			expect( scheduler.requests.length ).toBe( 1 );
 		} );
@@ -283,24 +484,30 @@ describe( 'Scheduler', () => {
 
 	describe( 'getScheduledRequest', () => {
 		it( 'finds a scheduled request', () => {
-			const scheduler = new Scheduler( () => {}, () => {}, () => {} );
-			const resourceName = 'resource1';
+			const operations = {
+				read: jest.fn(),
+			};
+			const scheduler = new Scheduler( operations, () => {}, () => {} );
 			const requirement1 = { freshness: 5 * MINUTE };
 			const resourceState = { lastReceived: threeMinutesAgo };
 
-			scheduler.scheduleRequest( resourceName, requirement1, resourceState, now );
-			const request = scheduler.getScheduledRequest( resourceName );
-			expect( request.resourceName ).toBe( resourceName );
+			scheduler.scheduleRequest( requirement1, resourceState, 'resource1', 'read', null );
+			const request = scheduler.getScheduledRequest( 'resource1' );
+			expect( request.resourceName ).toBe( 'resource1' );
+			expect( request.operation ).toBe( 'read' );
 			expect( request.getStatus() ).toBe( STATUS.scheduled );
 		} );
 
 		it( 'finds an overdue request', () => {
-			const scheduler = new Scheduler( () => {}, () => {}, () => {} );
+			const operations = {
+				read: jest.fn(),
+			};
+			const scheduler = new Scheduler( operations, () => {}, () => {} );
 			const resourceName = 'resource1';
 			const requirement1 = { freshness: 2 * MINUTE };
 			const resourceState = { lastReceived: threeMinutesAgo };
 
-			scheduler.scheduleRequest( resourceName, requirement1, resourceState, now );
+			scheduler.scheduleRequest( requirement1, resourceState, resourceName, 'read', null, now );
 			const request = scheduler.getScheduledRequest( resourceName );
 			expect( request.resourceName ).toBe( resourceName );
 			expect( request.getStatus() ).toBe( STATUS.overdue );
@@ -309,12 +516,15 @@ describe( 'Scheduler', () => {
 
 	describe( 'getInFlightRequests', () => {
 		it( 'finds any requests for a resource that are currently in-flight', () => {
-			const scheduler = new Scheduler( () => {}, () => {}, () => {} );
+			const operations = {
+				read: jest.fn(),
+			};
+			const scheduler = new Scheduler( operations, () => {}, () => {} );
 			const resourceName = 'resource1';
 			const requirement1 = { freshness: 5 * MINUTE };
 			const resourceState = { lastReceived: threeMinutesAgo };
 
-			scheduler.scheduleRequest( resourceName, requirement1, resourceState, now );
+			scheduler.scheduleRequest( requirement1, resourceState, resourceName, 'read', null, now );
 			scheduler.requests[ 0 ].getStatus = () => STATUS.inFlight;
 
 			const requests = scheduler.getInFlightRequests( resourceName );
@@ -325,138 +535,93 @@ describe( 'Scheduler', () => {
 		} );
 	} );
 
-	describe( 'isRequestReady', () => {
-		it( 'returns false if the resource is still fresh enough', () => {
-			const scheduler = new Scheduler( () => {}, () => {}, () => {} );
-			const resourceName = 'resource1';
-			const requirement1 = { freshness: 5 * MINUTE };
-			const resourceState = { lastReceived: threeMinutesAgo };
-
-			scheduler.scheduleRequest( resourceName, requirement1, resourceState, now );
-			expect( scheduler.isRequestReady( scheduler.requests[ 0 ] ) ).toBeFalsy();
-		} );
-
-		it( 'returns true if the resource is not fresh enough', () => {
-			const scheduler = new Scheduler( () => {}, () => {}, () => {} );
-			const resourceName = 'resource1';
-			const requirement1 = { freshness: 2 * MINUTE };
-			const resourceState = { lastReceived: threeMinutesAgo };
-
-			scheduler.scheduleRequest( resourceName, requirement1, resourceState, now );
-			expect( scheduler.isRequestReady( scheduler.requests[ 0 ] ) ).toBeTruthy();
-		} );
-
-		it( 'returns true if the resource has not yet been fetched', () => {
-			const scheduler = new Scheduler( () => {}, () => {}, () => {} );
-			const resourceName = 'resource1';
-			const requirement1 = {};
-			const resourceState = {};
-
-			scheduler.scheduleRequest( resourceName, requirement1, resourceState, now );
-			expect( scheduler.isRequestReady( scheduler.requests[ 0 ] ) ).toBeTruthy();
-		} );
-
-		it( 'returns false if the resource status is anything but scheduled or overdue', () => {
-			const scheduler = new Scheduler( () => {}, () => {}, () => {} );
-			const resourceName = 'resource1';
-			const requirement1 = {};
-			const resourceState = {};
-
-			scheduler.scheduleRequest( resourceName, requirement1, resourceState, now );
-			const request = scheduler.requests[ 0 ];
-
-			request.getStatus = () => STATUS.complete;
-			expect( scheduler.isRequestReady( request ) ).toBeFalsy();
-
-			request.getStatus = () => STATUS.failed;
-			expect( scheduler.isRequestReady( request ) ).toBeFalsy();
-
-			request.getStatus = () => STATUS.inFlight;
-			expect( scheduler.isRequestReady( request ) ).toBeFalsy();
-
-			request.getStatus = () => STATUS.timedOut;
-			expect( scheduler.isRequestReady( request ) ).toBeFalsy();
-
-			request.getStatus = () => STATUS.unnecessary;
-			expect( scheduler.isRequestReady( request ) ).toBeFalsy();
-		} );
-	} );
-
 	describe( 'sendReadyRequests', () => {
-		it( 'does nothing when there are no requests in queue', () => {
-			const scheduler = new Scheduler( () => {}, () => {}, () => {} );
-
-			expect( isEmpty( scheduler.requests ) ).toBeTruthy();
-			scheduler.sendReadyRequests();
-			expect( isEmpty( scheduler.requests ) ).toBeTruthy();
-		} );
-
 		it( 'does nothing when there are no scheduled or overdue requests in queue', () => {
-			const scheduler = new Scheduler( () => {}, () => {}, () => {} );
+			const operations = {
+				read: jest.fn(),
+			};
+			const scheduler = new Scheduler( operations, () => {}, () => {} );
 
-			scheduler.scheduleRequest( 'inFlightResource', {}, {}, now );
+			scheduler.scheduleRequest( {}, {}, 'inFlightResource', 'read', null, now );
 			scheduler.requests[ 0 ].getStatus = () => STATUS.inFlight;
 
-			scheduler.scheduleRequest( 'timedOutResource', {}, {}, now );
+			scheduler.scheduleRequest( {}, {}, 'timedOutResource', 'read', null, now );
 			scheduler.requests[ 1 ].getStatus = () => STATUS.timedOut;
 
-			scheduler.scheduleRequest( 'completeResource', {}, {}, now );
+			scheduler.scheduleRequest( {}, {}, 'completeResource', 'read', null, now );
 			scheduler.requests[ 2 ].getStatus = () => STATUS.complete;
 
-			scheduler.scheduleRequest( 'failedResource', {}, {}, now );
+			scheduler.scheduleRequest( {}, {}, 'failedResource', 'read', null, now );
 			scheduler.requests[ 3 ].getStatus = () => STATUS.failed;
 
-			scheduler.scheduleRequest( 'unnecessary', {}, {}, now );
+			scheduler.scheduleRequest( {}, {}, 'unnecessary', 'read', null, now );
 			scheduler.requests[ 4 ].getStatus = () => STATUS.unnecessary;
 
 			scheduler.sendReadyRequests( now );
 			expect( scheduler.requests.length ).toBe( 5 );
 		} );
 
-		it( 'Calls fetch with resource names', () => {
-			const fetch = jest.fn();
-			const scheduler = new Scheduler( fetch, () => {}, () => {} );
+		it( 'calls read with resource names', () => {
+			const operations = {
+				read: jest.fn(),
+			};
+			const scheduler = new Scheduler( operations, () => {}, () => {} );
 
 			scheduler.scheduleRequest(
-				'resource1',
 				{ freshness: 5 * MINUTE },
 				{},
+				'resource1',
+				'read',
+				null,
 				threeMinutesAgo
 			);
+
 			scheduler.scheduleRequest(
-				'resource2',
 				{ freshness: 3 * MINUTE },
 				{ lastReceived: fourMinutesAgo },
+				'resource2',
+				'read',
+				null,
 				threeMinutesAgo
 			);
 
 			expect( scheduler.requests[ 0 ].getStatus( threeMinutesAgo ) ).toBe( STATUS.scheduled );
 			expect( scheduler.requests[ 1 ].getStatus( threeMinutesAgo ) ).toBe( STATUS.scheduled );
 
-			fetch.mockReturnValue( Promise.resolve() );
+			operations.read.mockReturnValue( Promise.resolve() );
+			operations.read.mockReturnValue( Promise.resolve() );
 
-			return scheduler.sendReadyRequests( now ).then( () => {
-				expect( fetch ).toHaveBeenCalledWith( [
-					scheduler.requests[ 0 ].resourceName,
-					scheduler.requests[ 1 ].resourceName
-				] );
+			return scheduler.sendReadyRequests().then( () => {
+				expect( operations.read ).toHaveBeenCalledWith(
+					[
+						scheduler.requests[ 0 ].resourceName,
+						scheduler.requests[ 1 ].resourceName,
+					],
+					undefined
+				);
 			} );
 		} );
 
 		it( 'calls request.requested for each ready request', () => {
-			const fetch = jest.fn();
-			const scheduler = new Scheduler( fetch, () => {}, () => {} );
+			const operations = {
+				read: jest.fn(),
+			};
+			const scheduler = new Scheduler( operations, () => {}, () => {} );
 
 			scheduler.scheduleRequest(
-				'resource1',
 				{ freshness: 5 * MINUTE },
 				{},
+				'resource1',
+				'read',
+				null,
 				threeMinutesAgo
 			);
 			scheduler.scheduleRequest(
-				'resource2',
 				{ freshness: 3 * MINUTE },
 				{ lastReceived: fourMinutesAgo },
+				'resource2',
+				'read',
+				null,
 				threeMinutesAgo
 			);
 
@@ -464,7 +629,7 @@ describe( 'Scheduler', () => {
 			expect( scheduler.requests[ 1 ].getStatus( threeMinutesAgo ) ).toBe( STATUS.scheduled );
 
 			const promise = Promise.resolve();
-			fetch.mockReturnValue( promise );
+			operations.read.mockReturnValue( promise );
 
 			return scheduler.sendReadyRequests( now ).then( () => {
 				expect( scheduler.requests[ 0 ].getStatus( now ) ).toBe( STATUS.complete );
@@ -475,9 +640,12 @@ describe( 'Scheduler', () => {
 
 	describe( 'cleanUp', () => {
 		it( 'does not clear scheduled requests', () => {
-			const scheduler = new Scheduler( () => {}, () => {}, () => {} );
+			const operations = {
+				read: jest.fn(),
+			};
+			const scheduler = new Scheduler( operations, () => {}, () => {} );
 
-			scheduler.scheduleRequest( 'scheduledResource', {}, {}, now );
+			scheduler.scheduleRequest( {}, {}, 'scheduledResource', 'read', null, now );
 			scheduler.requests[ 0 ].getStatus = () => STATUS.scheduled;
 
 			expect( scheduler.requests.length ).toBe( 1 );
@@ -489,66 +657,121 @@ describe( 'Scheduler', () => {
 		} );
 
 		it( 'clears out completed and failed requests', () => {
-			const scheduler = new Scheduler( () => {}, () => {}, () => {} );
+			const operations = {
+				read: jest.fn(),
+			};
+			const scheduler = new Scheduler( operations, () => {}, () => {} );
 
-			scheduler.scheduleRequest( 'scheduledResource', {}, {}, now );
+			scheduler.scheduleRequest( {}, {}, 'scheduledResource', 'read', null, now );
 			scheduler.requests[ 0 ].getStatus = () => STATUS.scheduled;
 
-			scheduler.scheduleRequest( 'completeResource', {}, {}, now );
+			scheduler.scheduleRequest( {}, {}, 'completeResource', 'read', null, now );
 			scheduler.requests[ 1 ].getStatus = () => STATUS.complete;
 
-			scheduler.scheduleRequest( 'failedResource', {}, {}, now );
+			scheduler.scheduleRequest( {}, {}, 'failedResource', 'read', null, now );
 			scheduler.requests[ 2 ].getStatus = () => STATUS.failed;
 
 			expect( scheduler.requests.length ).toBe( 3 );
 
-			scheduler.cleanUp( now );
+			scheduler.cleanUp();
 
 			expect( scheduler.requests.length ).toBe( 1 );
 			expect( scheduler.requests[ 0 ].getStatus() ).toBe( STATUS.scheduled );
+		} );
+
+		it( 'combines data from multiple requests into one operation call', () => {
+			const operations = {
+				write: jest.fn(),
+			};
+			const scheduler = new Scheduler( operations, () => {}, () => {} );
+
+			scheduler.scheduleRequest(
+				{},
+				{},
+				'resource1',
+				'write',
+				{ oneA: '1a' },
+				now
+			);
+
+			scheduler.scheduleRequest(
+				{},
+				{},
+				'resource1',
+				'write',
+				{ oneB: '1b' },
+				now
+			);
+
+			scheduler.scheduleRequest(
+				{},
+				{},
+				'resource2',
+				'write',
+				{ twoA: '2a' },
+				now
+			);
+
+			return scheduler.sendReadyRequests( now ).then( () => {
+				expect( operations.write ).toHaveBeenCalledWith(
+					[ 'resource1', 'resource2' ],
+					{ resource1: { oneA: '1a', oneB: '1b' }, resource2: { twoA: '2a' } },
+				);
+			} );
 		} );
 	} );
 
 	describe( 'resendTimeouts', () => {
 		it( 'does nothing when no requests are timed out', () => {
-			const fetch = jest.fn();
-			const scheduler = new Scheduler( fetch, () => {}, () => {} );
+			const operations = {
+				read: jest.fn(),
+			};
+			const scheduler = new Scheduler( operations, () => {}, () => {} );
 
 			scheduler.scheduleRequest(
-				'resource1',
 				{ freshness: 5 * MINUTE, timeout: 5 * SECOND },
 				{},
+				'resource1',
+				'read',
+				null,
 				threeMinutesAgo
 			);
 
 			return scheduler.resendTimeouts().then( () => {
-				expect( fetch ).not.toHaveBeenCalled();
+				expect( operations.read ).not.toHaveBeenCalled();
 			} );
 		} );
 
 		it( 're-sends timed out requests', () => {
-			const fetch = jest.fn();
-			const scheduler = new Scheduler( fetch, () => {}, () => {} );
+			const operations = {
+				read: jest.fn(),
+			};
+			const scheduler = new Scheduler( operations, () => {}, () =>  {} );
 
 			scheduler.scheduleRequest(
-				'resource1',
 				{ freshness: 5 * MINUTE, timeout: 5 * SECOND },
 				{},
+				'resource1',
+				'read',
+				null,
 				threeMinutesAgo
 			);
 			scheduler.requests[ 0 ].getStatus = () => STATUS.timedOut;
 
-			fetch.mockReturnValue( Promise.resolve() );
+			operations.read.mockReturnValue( Promise.resolve() );
 
-			return scheduler.resendTimeouts( now ).then( () => {
-				expect( fetch ).toHaveBeenCalledWith( [ scheduler.requests[ 0 ].resourceName ] );
+			return scheduler.resendTimeouts().then( () => {
+				expect( operations.read ).toHaveBeenCalledWith(
+					[ scheduler.requests[ 0 ].resourceName ],
+					undefined
+				);
 			} );
 		} );
 	} );
 
 	describe( 'processRequests', () => {
 		it( 'should clean up, send ready requests, resend timeouts, and update the delay', () => {
-			const scheduler = new Scheduler( () => {}, () => {}, () => {} );
+			const scheduler = new Scheduler( {}, () => {}, () => {} );
 			scheduler.cleanUp = jest.fn();
 			scheduler.sendReadyRequests = jest.fn();
 			scheduler.resendTimeouts = jest.fn();

--- a/packages/framework/src/client/__tests__/scheduler.spec.js
+++ b/packages/framework/src/client/__tests__/scheduler.spec.js
@@ -35,7 +35,7 @@ describe( 'combineRequestData', () => {
 
 	it( 'should handle requests with no data', () => {
 		const request1a = new ResourceRequest( {}, {}, 'resource1', 'read', undefined, now );
-		const request1b = new ResourceRequest( {}, {}, 'resource1', 'read', null, now );
+		const request1b = new ResourceRequest( {}, {}, 'resource1', 'read', undefined, now );
 
 		const data = combineRequestData( [ request1a, request1b ] );
 
@@ -184,7 +184,7 @@ describe( 'Scheduler', () => {
 
 			expect( scheduler.getNextRequestDelay() ).toBeNull();
 
-			scheduler.scheduleRequest( {}, {}, 'completeResource', 'read', null, now );
+			scheduler.scheduleRequest( {}, {}, 'completeResource', 'read', undefined, now );
 			scheduler.requests[ 0 ].getStatus = () => STATUS.complete;
 
 			expect( scheduler.getNextRequestDelay( now ) ).toBeNull();
@@ -196,7 +196,7 @@ describe( 'Scheduler', () => {
 			};
 			const scheduler = new Scheduler( operations, () => {}, () => {} );
 
-			scheduler.scheduleRequest( {}, {}, 'resource1', 'read', null, threeMinutesAgo );
+			scheduler.scheduleRequest( {}, {}, 'resource1', 'read', undefined, threeMinutesAgo );
 
 			expect( scheduler.getNextRequestDelay( now ) ).toBe( 0 );
 		} );
@@ -211,7 +211,7 @@ describe( 'Scheduler', () => {
 				{ freshness: 5 * MINUTE },
 				{ lastReceived: threeMinutesAgo },
 				'resource1',
-				null,
+				undefined,
 				now
 			);
 
@@ -228,10 +228,10 @@ describe( 'Scheduler', () => {
 				{ freshness: 5 * MINUTE },
 				{ lastReceived: threeMinutesAgo },
 				'resource1',
-				null,
+				undefined,
 				now
 			);
-			scheduler.scheduleRequest( {}, {}, 'resource1', null, now );
+			scheduler.scheduleRequest( {}, {}, 'resource1', undefined, now );
 
 			expect( scheduler.getNextRequestDelay( now ) ).toBe( 0 );
 		} );
@@ -246,7 +246,7 @@ describe( 'Scheduler', () => {
 				{ freshness: 5 * MINUTE },
 				{ lastReceived: threeMinutesAgo },
 				'resource1',
-				null,
+				undefined,
 				now
 			);
 			const delayBefore = scheduler.getNextRequestDelay( now );
@@ -255,7 +255,7 @@ describe( 'Scheduler', () => {
 				{ freshness: 30 * MINUTE },
 				{ lastReceived: fourMinutesAgo },
 				'resource1',
-				null,
+				undefined,
 				now
 			);
 			const delayAfter = scheduler.getNextRequestDelay( now );
@@ -281,7 +281,7 @@ describe( 'Scheduler', () => {
 			const scheduler = new Scheduler( {}, setTimeout, () => {} );
 
 			scheduler.requests.push(
-				new ResourceRequest( { freshness: 5 * MINUTE }, { lastReceived: threeMinutesAgo }, 'resource1', null, now )
+				new ResourceRequest( { freshness: 5 * MINUTE }, { lastReceived: threeMinutesAgo }, 'resource1', undefined, now )
 			);
 			scheduler.updateDelay( now );
 
@@ -295,7 +295,7 @@ describe( 'Scheduler', () => {
 			const scheduler = new Scheduler( {}, setTimeout, () => {} );
 
 			scheduler.requests.push(
-				new ResourceRequest( { freshness: 2 * MINUTE }, { lastReceived: threeMinutesAgo }, 'resource1', null, now )
+				new ResourceRequest( { freshness: 2 * MINUTE }, { lastReceived: threeMinutesAgo }, 'resource1', undefined, now )
 			);
 			scheduler.updateDelay( now );
 
@@ -309,14 +309,14 @@ describe( 'Scheduler', () => {
 			const scheduler = new Scheduler( {}, setTimeout, () => {} );
 
 			scheduler.requests.push(
-				new ResourceRequest( { freshness: 5 * MINUTE }, { lastReceived: threeMinutesAgo }, 'resource1', null, now )
+				new ResourceRequest( { freshness: 5 * MINUTE }, { lastReceived: threeMinutesAgo }, 'resource1', undefined, now )
 			);
 			scheduler.updateDelay( now );
 
 			expect( setTimeout ).toHaveBeenCalledTimes( 1 );
 
 			scheduler.requests.push(
-				new ResourceRequest( { freshness: 4 * MINUTE }, { lastReceived: threeMinutesAgo }, 'resource1', null, now )
+				new ResourceRequest( { freshness: 4 * MINUTE }, { lastReceived: threeMinutesAgo }, 'resource1', undefined, now )
 			);
 			scheduler.updateDelay( now );
 
@@ -331,14 +331,14 @@ describe( 'Scheduler', () => {
 			const scheduler = new Scheduler( {}, setTimeout, () => {} );
 
 			scheduler.requests.push(
-				new ResourceRequest( { freshness: 5 * MINUTE }, { lastReceived: threeMinutesAgo }, 'resource1', null, now )
+				new ResourceRequest( { freshness: 5 * MINUTE }, { lastReceived: threeMinutesAgo }, 'resource1', undefined, now )
 			);
 			scheduler.updateDelay( now );
 
 			expect( setTimeout ).toHaveBeenCalledTimes( 1 );
 
 			scheduler.requests.push(
-				new ResourceRequest( {}, {}, 'resource2', null, now )
+				new ResourceRequest( {}, {}, 'resource2', undefined, now )
 			);
 			scheduler.updateDelay( now );
 
@@ -353,7 +353,7 @@ describe( 'Scheduler', () => {
 			const scheduler = new Scheduler( {}, setTimeout, () => {} );
 
 			scheduler.requests.push(
-				new ResourceRequest( { freshness: 5 * MINUTE }, { lastReceived: fourMinutesAgo }, 'resource1', null, threeMinutesAgo )
+				new ResourceRequest( { freshness: 5 * MINUTE }, { lastReceived: fourMinutesAgo }, 'resource1', undefined, threeMinutesAgo )
 			);
 			scheduler.updateDelay( threeMinutesAgo );
 
@@ -383,7 +383,7 @@ describe( 'Scheduler', () => {
 			const scheduler = new Scheduler( {}, setTimeout, clearTimeout );
 
 			scheduler.requests.push(
-				new ResourceRequest( { freshness: 5 * MINUTE }, { lastReceived: threeMinutesAgo }, 'resource1', null, now )
+				new ResourceRequest( { freshness: 5 * MINUTE }, { lastReceived: threeMinutesAgo }, 'resource1', undefined, now )
 			);
 			scheduler.updateDelay( now );
 
@@ -414,7 +414,7 @@ describe( 'Scheduler', () => {
 			};
 			const scheduler = new Scheduler( operations, () => {}, () => {} );
 
-			scheduler.scheduleRequest( {}, {}, 'resource1', 'read', null, threeMinutesAgo );
+			scheduler.scheduleRequest( {}, {}, 'resource1', 'read', undefined, threeMinutesAgo );
 			const request = scheduler.requests[ 0 ];
 
 			expect( request ).not.toBe( undefined );
@@ -447,15 +447,15 @@ describe( 'Scheduler', () => {
 			const requirement3 = { freshness: 2 * MINUTE };
 			const resourceState = { lastReceived: threeMinutesAgo };
 
-			scheduler.scheduleRequest( requirement1, resourceState, 'resource1', 'read', null, now );
+			scheduler.scheduleRequest( requirement1, resourceState, 'resource1', 'read', undefined, now );
 			expect( scheduler.requests[ 0 ].getStatus( now ) ).toBe( STATUS.scheduled );
 			expect( scheduler.requests[ 0 ].getTimeLeft( now ) ).toBe( 2 * MINUTE );
 
-			scheduler.scheduleRequest( requirement2, resourceState, 'resource1', 'read', null, now );
+			scheduler.scheduleRequest( requirement2, resourceState, 'resource1', 'read', undefined, now );
 			expect( scheduler.requests[ 0 ].getStatus( now ) ).toBe( STATUS.scheduled );
 			expect( scheduler.requests[ 0 ].getTimeLeft( now ) ).toBe( 1 * MINUTE );
 
-			scheduler.scheduleRequest( requirement3, resourceState, 'resource1', 'read', null, now );
+			scheduler.scheduleRequest( requirement3, resourceState, 'resource1', 'read', undefined, now );
 			expect( scheduler.requests[ 0 ].getStatus( now ) ).toBe( STATUS.overdue );
 			expect( scheduler.requests[ 0 ].getTimeLeft( now ) ).toBe( -( 1 * MINUTE ) );
 		} );
@@ -469,13 +469,13 @@ describe( 'Scheduler', () => {
 			const requirement2 = { freshness: 4 * MINUTE };
 			const resourceState = { lastReceived: threeMinutesAgo };
 
-			scheduler.scheduleRequest( requirement1, resourceState, 'resource1', 'read', null, now );
+			scheduler.scheduleRequest( requirement1, resourceState, 'resource1', 'read', undefined, now );
 			expect( scheduler.requests.length ).toBe( 1 );
 			expect( scheduler.requests[ 0 ].getStatus( now ) ).toBe( STATUS.scheduled );
 			expect( scheduler.requests[ 0 ].getTimeLeft( now ) ).toBe( 2 * MINUTE );
 
 			scheduler.requests[ 0 ].getStatus = () => STATUS.inFlight;
-			scheduler.scheduleRequest( requirement2, resourceState, 'resource1', 'read', null, now );
+			scheduler.scheduleRequest( requirement2, resourceState, 'resource1', 'read', undefined, now );
 
 			expect( scheduler.requests.length ).toBe( 1 );
 		} );
@@ -524,7 +524,7 @@ describe( 'Scheduler', () => {
 			const requirement1 = { freshness: 5 * MINUTE };
 			const resourceState = { lastReceived: threeMinutesAgo };
 
-			scheduler.scheduleRequest( requirement1, resourceState, 'resource1', 'read', null );
+			scheduler.scheduleRequest( requirement1, resourceState, 'resource1', 'read', undefined );
 			const request = scheduler.getScheduledRequest( 'resource1', 'read' );
 			expect( request.resourceName ).toBe( 'resource1' );
 			expect( request.operation ).toBe( 'read' );
@@ -539,7 +539,7 @@ describe( 'Scheduler', () => {
 			const requirement1 = { freshness: 2 * MINUTE };
 			const resourceState = { lastReceived: threeMinutesAgo };
 
-			scheduler.scheduleRequest( requirement1, resourceState, 'resource1', 'read', null, now );
+			scheduler.scheduleRequest( requirement1, resourceState, 'resource1', 'read', undefined, now );
 			const request = scheduler.getScheduledRequest( 'resource1', 'read' );
 			expect( request.resourceName ).toBe( 'resource1' );
 			expect( request.getStatus() ).toBe( STATUS.overdue );
@@ -555,7 +555,7 @@ describe( 'Scheduler', () => {
 			const requirement1 = { freshness: 5 * MINUTE };
 			const resourceState = { lastReceived: threeMinutesAgo };
 
-			scheduler.scheduleRequest( requirement1, resourceState, 'resource1', 'read', null, now );
+			scheduler.scheduleRequest( requirement1, resourceState, 'resource1', 'read', undefined, now );
 			scheduler.requests[ 0 ].getStatus = () => STATUS.inFlight;
 
 			const requests = scheduler.getInFlightRequests( 'resource1', 'read' );
@@ -576,19 +576,19 @@ describe( 'Scheduler', () => {
 			const dataReceived = jest.fn();
 			scheduler.setDataHandlers( dataRequested, dataReceived );
 
-			scheduler.scheduleRequest( {}, {}, 'inFlightResource', 'read', null, now );
+			scheduler.scheduleRequest( {}, {}, 'inFlightResource', 'read', undefined, now );
 			scheduler.requests[ 0 ].getStatus = () => STATUS.inFlight;
 
-			scheduler.scheduleRequest( {}, {}, 'timedOutResource', 'read', null, now );
+			scheduler.scheduleRequest( {}, {}, 'timedOutResource', 'read', undefined, now );
 			scheduler.requests[ 1 ].getStatus = () => STATUS.timedOut;
 
-			scheduler.scheduleRequest( {}, {}, 'completeResource', 'read', null, now );
+			scheduler.scheduleRequest( {}, {}, 'completeResource', 'read', undefined, now );
 			scheduler.requests[ 2 ].getStatus = () => STATUS.complete;
 
-			scheduler.scheduleRequest( {}, {}, 'failedResource', 'read', null, now );
+			scheduler.scheduleRequest( {}, {}, 'failedResource', 'read', undefined, now );
 			scheduler.requests[ 3 ].getStatus = () => STATUS.failed;
 
-			scheduler.scheduleRequest( {}, {}, 'unnecessary', 'read', null, now );
+			scheduler.scheduleRequest( {}, {}, 'unnecessary', 'read', undefined, now );
 			scheduler.requests[ 4 ].getStatus = () => STATUS.unnecessary;
 
 			return scheduler.sendReadyRequests( now ).then( () => {
@@ -609,7 +609,7 @@ describe( 'Scheduler', () => {
 				{},
 				'resource1',
 				'read',
-				null,
+				undefined,
 				threeMinutesAgo
 			);
 
@@ -618,7 +618,7 @@ describe( 'Scheduler', () => {
 				{ lastReceived: fourMinutesAgo },
 				'resource2',
 				'read',
-				null,
+				undefined,
 				threeMinutesAgo
 			);
 
@@ -650,7 +650,7 @@ describe( 'Scheduler', () => {
 				{},
 				'resource1',
 				'read',
-				null,
+				undefined,
 				threeMinutesAgo
 			);
 			scheduler.scheduleRequest(
@@ -658,7 +658,7 @@ describe( 'Scheduler', () => {
 				{ lastReceived: fourMinutesAgo },
 				'resource2',
 				'read',
-				null,
+				undefined,
 				threeMinutesAgo
 			);
 
@@ -682,7 +682,7 @@ describe( 'Scheduler', () => {
 			};
 			const scheduler = new Scheduler( operations, () => {}, () => {} );
 
-			scheduler.scheduleRequest( {}, {}, 'scheduledResource', 'read', null, now );
+			scheduler.scheduleRequest( {}, {}, 'scheduledResource', 'read', undefined, now );
 			scheduler.requests[ 0 ].getStatus = () => STATUS.scheduled;
 
 			expect( scheduler.requests.length ).toBe( 1 );
@@ -699,13 +699,13 @@ describe( 'Scheduler', () => {
 			};
 			const scheduler = new Scheduler( operations, () => {}, () => {} );
 
-			scheduler.scheduleRequest( {}, {}, 'scheduledResource', 'read', null, now );
+			scheduler.scheduleRequest( {}, {}, 'scheduledResource', 'read', undefined, now );
 			scheduler.requests[ 0 ].getStatus = () => STATUS.scheduled;
 
-			scheduler.scheduleRequest( {}, {}, 'completeResource', 'read', null, now );
+			scheduler.scheduleRequest( {}, {}, 'completeResource', 'read', undefined, now );
 			scheduler.requests[ 1 ].getStatus = () => STATUS.complete;
 
-			scheduler.scheduleRequest( {}, {}, 'failedResource', 'read', null, now );
+			scheduler.scheduleRequest( {}, {}, 'failedResource', 'read', undefined, now );
 			scheduler.requests[ 2 ].getStatus = () => STATUS.failed;
 
 			expect( scheduler.requests.length ).toBe( 3 );
@@ -776,7 +776,7 @@ describe( 'Scheduler', () => {
 				{},
 				'resource1',
 				'read',
-				null,
+				undefined,
 				threeMinutesAgo
 			);
 
@@ -825,7 +825,7 @@ describe( 'Scheduler', () => {
 				{},
 				'resource1',
 				'read',
-				null,
+				undefined,
 				threeMinutesAgo
 			);
 
@@ -867,7 +867,7 @@ describe( 'Scheduler', () => {
 				{},
 				'resource1',
 				'read',
-				null,
+				undefined,
 				threeMinutesAgo
 			);
 
@@ -887,7 +887,7 @@ describe( 'Scheduler', () => {
 				{},
 				'resource1',
 				'read',
-				null,
+				undefined,
 				threeMinutesAgo
 			);
 			scheduler.requests[ 0 ].getStatus = () => STATUS.timedOut;

--- a/packages/framework/src/client/resource-request.js
+++ b/packages/framework/src/client/resource-request.js
@@ -1,5 +1,5 @@
 import debugFactory from 'debug';
-import { isEqual, isMatch, isNil } from 'lodash';
+import { isMatch, isNil } from 'lodash';
 import { isDateEarlier } from '../utils/dates';
 import { SECOND } from '../utils/constants';
 

--- a/packages/framework/src/client/resource-request.js
+++ b/packages/framework/src/client/resource-request.js
@@ -135,7 +135,6 @@ export default class ResourceRequest {
 		this.debug( `Request for ${ this.resourceName } submitted...` );
 		this.timeRequested = now;
 		this.promise = promise;
-		return this.promise.then( this.requestComplete, this.requestFailed );
 	}
 
 	requestComplete = () => {

--- a/packages/framework/src/client/scheduler.js
+++ b/packages/framework/src/client/scheduler.js
@@ -103,7 +103,7 @@ export default class Scheduler {
 	/**
 	 * Finds a request that is either scheduled or overdue.
 	 * @param {string} resourceName The name of the resource for the operation
-	 * @param {string} operation The name of the operation to be performed (defaults to 'read')
+	 * @param {string} operation The name of the operation to be performed
 	 * @param {Date} now The current time.
 	 * @return {ResourceRequest} The scheduled request, or null if none found
 	 */
@@ -121,7 +121,7 @@ export default class Scheduler {
 	/**
 	 * Finds requests that are in flight by resourceName
 	 * @param {string} resourceName The name of the resource to check
-	 * @param {string} operation The name of the operation to be performed (defaults to 'read')
+	 * @param {string} operation The name of the operation to be performed
 	 * @param {Date} now The current time.
 	 * @return {Array} Any requests for the given resource which are currently in flight.
 	 */
@@ -140,7 +140,7 @@ export default class Scheduler {
 	 * @param {Object} requirement The set of requirements (freshness, timeout)
 	 * @param {Object} resourceState The current snapshot of resource state
 	 * @param {string} resourceName The name of the resource for the operation
-	 * @param {string} operation The name of the operation to be performed (defaults to 'read')
+	 * @param {string} operation The name of the operation to be performed
 	 * @param {Object} data The data to be sent for the operation (defaults to undefined)
 	 * @param {Date} now The current time.
 	 */

--- a/packages/framework/src/client/scheduler.js
+++ b/packages/framework/src/client/scheduler.js
@@ -204,7 +204,7 @@ export default class Scheduler {
 		Object.keys( requestsByOperation ).forEach( ( operationName ) => {
 			// Send one operation, and associate all requests for it
 			const operationFunc = this.operations[ operationName ];
-			promises.push( sendOperation( operationFunc, requests, this.dataReceived ) );
+			promises.push( sendOperation( operationFunc, requests, this.dataReceived, now ) );
 		} );
 
 		// Return a list of operation promises

--- a/packages/framework/src/client/scheduler.js
+++ b/packages/framework/src/client/scheduler.js
@@ -141,7 +141,7 @@ export default class Scheduler {
 	 * @param {Object} resourceState The current snapshot of resource state
 	 * @param {string} resourceName The name of the resource for the operation
 	 * @param {string} operation The name of the operation to be performed (defaults to 'read')
-	 * @param {Object} data The data to be sent for the operation (defaults to null)
+	 * @param {Object} data The data to be sent for the operation (defaults to undefined)
 	 * @param {Date} now The current time.
 	 */
 	scheduleRequest = (
@@ -149,7 +149,7 @@ export default class Scheduler {
 		resourceState,
 		resourceName,
 		operation,
-		data = null,
+		data = undefined,
 		now = new Date()
 	) => {
 		const identicalInFlightRequest = find(


### PR DESCRIPTION
Partially addresses #203 

Add operations to scheduler and requests

This allows all operations to be scheduled instead of just read
operations. This will allow the possibility of batched requests for all
operation types. Another functional benefit of this approach is that all API operations are in one place and easier to track/debug.

To Test:
1. `npm install`
2. `npm run bootstrap`
3. `npm run lint`
4. `npm run test`
