### PR TITLE
Render-based refactor: Step 5

### DIFF
--- a/packages/framework/src/devinfo/__tests__/index.spec.js
+++ b/packages/framework/src/devinfo/__tests__/index.spec.js
@@ -1,0 +1,57 @@
+import ApiClient from '../../client';
+import { isDevInfoEnabled, updateDevInfo } from '../';
+
+describe( 'devinfo', () => {
+    describe( 'isDevInfoEnabled', () => {
+        it( 'should be disabled by default', () => {
+            expect( isDevInfoEnabled() ).toBeFalsy();
+        } )
+
+        it( 'should enable when the window global is true', () => {
+            global.window.__FRESH_DATA_DEV_INFO__ = true;
+            expect( isDevInfoEnabled() ).toBeTruthy();
+        } );
+
+        it( 'should disbale when the window global is false', () => {
+            global.window.__FRESH_DATA_DEV_INFO__ = false;
+            expect( isDevInfoEnabled() ).toBeFalsy();
+        } );
+    } );
+
+    describe( 'updateDevInfo', () => {
+        it( 'should not have window.freshData set by default', () => {
+            expect( global.window.freshData ).toBeUndefined();
+        } );
+
+        it( 'should not set window.freshData when devinfo is not enabled', () => {
+            const apiSpec = { name: 'apiSpecName' };
+            const client = new ApiClient( apiSpec );
+            updateDevInfo( client );
+            expect( global.window.freshData ).toBeUndefined();
+        } );
+
+        it( 'should set window.freshData when devinfo is enabled', () => {
+            const apiSpec = { name: 'myapi' };
+            const client = new ApiClient( apiSpec );
+
+            global.window.__FRESH_DATA_DEV_INFO__ = true;
+
+            updateDevInfo( client );
+            expect( global.window.freshData ).not.toBeUndefined();
+            expect( global.window.freshData.myapi ).not.toBeUndefined();
+        } );
+
+        it( 'should not create window.freshData twice', () => {
+            const apiSpec = { name: 'myapi' };
+            const client = new ApiClient( apiSpec );
+
+            global.window.__FRESH_DATA_DEV_INFO__ = true;
+
+            updateDevInfo( client );
+            const devInfo = global.window.freshData;
+
+            updateDevInfo( client );
+            expect( global.window.freshData ).toBe( devInfo );
+        } );
+    } );
+} );

--- a/packages/framework/src/devinfo/__tests__/index.spec.js
+++ b/packages/framework/src/devinfo/__tests__/index.spec.js
@@ -5,7 +5,7 @@ describe( 'devinfo', () => {
     describe( 'isDevInfoEnabled', () => {
         it( 'should be disabled by default', () => {
             expect( isDevInfoEnabled() ).toBeFalsy();
-        } )
+        } );
 
         it( 'should enable when the window global is true', () => {
             global.window.__FRESH_DATA_DEV_INFO__ = true;
@@ -52,6 +52,15 @@ describe( 'devinfo', () => {
 
             updateDevInfo( client );
             expect( global.window.freshData ).toBe( devInfo );
+        } );
+
+        it( 'should link the requests from the scheduler', () => {
+            global.window.__FRESH_DATA_DEV_INFO__ = true;
+
+            const apiSpec = { name: 'myapi' };
+            const client = new ApiClient( apiSpec );
+
+            expect( global.window.freshData.myapi.requests ).toBe( client.scheduler.requests );
         } );
     } );
 } );

--- a/packages/framework/src/devinfo/index.js
+++ b/packages/framework/src/devinfo/index.js
@@ -27,8 +27,7 @@ export function updateDevInfo( client ) {
  */
 function generateDevInfo( client ) {
 	const info = {
-		// TODO: Re-add info based on scheduler data.
-		name: client.getName(),
+		requests: client.scheduler.requests,
 	};
 
 	return info;


### PR DESCRIPTION
Partially addresses #203 

This updates the devinfo with a link to the scheduler requests queue. The requests themselves have enough information in them to be useful from the console without further extra parsing. Note that this will essentially allow requests to be modified from the command line when devinfo is enabled.

To Test:
1. `npm install`
2. `npm run bootstrap`
3. `npm run lint`
4. `npm run test`

To view in the browser JS console using the wp-rest-api example:
1. `npm install`
2. `npm run bootstrap`
3. `npm run build`
4. `cd packages/react-provider; rm -rf node_modules/react-redux; cd ../../` (this fixes a quirky module conflict)
5. `cd examples/wp-rest-api`
6. `npm start`

Pro tip: In the browser console type `localStorage.setItem( 'debug', 'fresh-data:*' );` to see the debug output for everything.
