### PR TITLE
Fix resources fetching twice

### DIFF
--- a/packages/framework/src/client/__tests__/index.spec.js
+++ b/packages/framework/src/client/__tests__/index.spec.js
@@ -146,15 +146,19 @@ describe( 'ApiClient', () => {
 	describe( '#setDataHandlers', () => {
 		it( 'should set the data handlers on the scheduler', () => {
 			const apiClient = new ApiClient( {} );
-			apiClient.scheduler.setDataHandlers = jest.fn();
 
-			const dataRequested = () => {};
-			const dataReceived = () => {};
+			const dataRequested = jest.fn();
+			const dataReceived = jest.fn();
 
 			apiClient.setDataHandlers( { dataRequested, dataReceived } );
 
-			expect( apiClient.scheduler.setDataHandlers ).toHaveBeenCalledTimes( 1 );
-			expect( apiClient.scheduler.setDataHandlers ).toHaveBeenCalledWith( dataRequested, dataReceived );
+			apiClient.scheduler.dataRequested( { 1: 'one' } );
+			apiClient.scheduler.dataReceived( { 2: 'two' } );
+
+			expect( dataRequested ).toHaveBeenCalledTimes( 1 );
+			expect( dataRequested ).toHaveBeenCalledWith( { 1: 'one' } );
+			expect( dataReceived ).toHaveBeenCalledTimes( 1 );
+			expect( dataReceived ).toHaveBeenCalledWith( { 2: 'two' } );
 		} );
 	} );
 

--- a/packages/framework/src/client/__tests__/index.spec.js
+++ b/packages/framework/src/client/__tests__/index.spec.js
@@ -212,6 +212,7 @@ describe( 'ApiClient', () => {
 		it( 'should schedule a request for a resource that does not yet exist.', () => {
 			const apiClient = new ApiClient( emptyApiSpec );
 			apiClient.scheduler.scheduleRequest = jest.fn();
+			apiClient.setState( {} );
 
 			apiClient.requireResource( {}, 'thing:1', now );
 
@@ -222,7 +223,7 @@ describe( 'ApiClient', () => {
 		it( 'should schedule a request for a resource that already exists.', () => {
 			const apiClient = new ApiClient( emptyApiSpec );
 			apiClient.scheduler.scheduleRequest = jest.fn();
-			apiClient.state = { resources: { 'thing:1': { lastReceived: 2 * SECOND } } };
+			apiClient.setState( { resources: { 'thing:1': { lastReceived: 2 * SECOND } } } );
 
 			const requirement = { freshness: 5 * SECOND };
 

--- a/packages/framework/src/client/index.js
+++ b/packages/framework/src/client/index.js
@@ -19,7 +19,10 @@ export default class ApiClient {
 		this.subscriptionCallbacks = new Set();
 		this.state = {};
 		// TODO: This will no longer be necessary when redux state is simplified out.
-		this.isStateStale = false;
+		// This variable is used to keep track of the moment
+		// between the data handler being called and the new state being set on the client.
+		// During this moment, no requests should be scheduled because they'd be working on timestamps that are out of date.
+		this.isClientStateInSync = false;
 
 		this.readOperationName = readOperationName;
 
@@ -50,10 +53,10 @@ export default class ApiClient {
 	// TODO: This function will no longer be necessary when redux state is simplified out.
 	setDataHandlers = ( { dataRequested, dataReceived } ) => {
 		this.scheduler.setDataHandlers( ( resourceNames ) => {
-			this.isStateStale = true;
+			this.isClientStateInSync = false;
 			dataRequested( resourceNames );
 		}, ( resources ) => {
-			this.isStateStale = true;
+			this.isClientStateInSync = false;
 			dataReceived( resources );
 		} );
 	}
@@ -64,7 +67,7 @@ export default class ApiClient {
 			this.subscriptionCallbacks.forEach( ( callback ) => callback( this ) );
 			updateDevInfo( this );
 		}
-		this.isStateStale = false;
+		this.isClientStateInSync = true;
 	}
 
 	subscribe = ( callback ) => {
@@ -98,7 +101,7 @@ export default class ApiClient {
 		// This is necessary because components are getting re-rendered twice when dataReceived is dispatched.
 		// First before the state is updated, and second afterwards. This prevents resources from getting rescheduled
 		// on the first re-render. After redux dispatching is no longer used, components should no longer re-render twice.
-		if ( ! this.isStateStale ) {
+		if ( this.isClientStateInSync ) {
 			this.scheduler.scheduleRequest( requirement, resourceState, resourceName, this.readOperationName, undefined, now );
 		}
 		return this.getResource( resourceName );

--- a/packages/framework/src/client/scheduler.js
+++ b/packages/framework/src/client/scheduler.js
@@ -266,7 +266,9 @@ export async function sendOperation( operation, requests, dataReceived, now ) {
 		requests.forEach( ( request ) => {
 			request.requestComplete();
 		} );
-		resourceSets.forEach( ( resources ) => dataReceived( resources ) );
+		resourceSets.forEach( ( resources ) => {
+			dataReceived( resources );
+		} );
 	} ).catch( ( error ) => {
 		requests.forEach( ( request ) => {
 			request.requestFailed( error );

--- a/packages/react-provider/src/__tests__/provider.spec.js
+++ b/packages/react-provider/src/__tests__/provider.spec.js
@@ -122,9 +122,6 @@ describe( 'ApiProvider', () => {
 			);
 			const provider = wrapper.instance();
 
-			expect( provider.apiClient.scheduler.dataRequested ).toBe( provider.dataRequested );
-			expect( provider.apiClient.scheduler.dataReceived ).toBe( provider.dataReceived );
-
 			provider.dataRequested( [ 'one', 'two' ] );
 
 			expect( dataRequested ).toHaveBeenCalledTimes( 1 );


### PR DESCRIPTION
Fixes #233 

This fixes the problem where resources were getting fetched twice
because of the way react-redux connect works with rendering components
and sending out redux store subscriptions.

Disclaimer: This fix is a bit hacky to get around an issue we're having with redux where reducers are processed before subscribers to the redux store. I've been thinking of removing redux completely from fresh-data as a dependency and this is pushing me more in that direction.

To Test:
1. `npm install`
2. `npm run bootstrap`
3. `npm run build`
4. `rm -rf packages/react-provider/node_modules/react-redux` (necessary because of local linking issues)
5. `cd examples/wp-rest-api`
6. `npm start`

After this, you should be able to observe only one initial fetch instead of two when using the code on master. (pro-tip: in the JS console run `localStorage.setItem( 'debug', 'fresh-data:*' );` to see debug messages.
