### PR TITLE
Fix isClientStateInSync for withSelect

### DIFF
--- a/packages/framework/src/client/index.js
+++ b/packages/framework/src/client/index.js
@@ -80,12 +80,14 @@ export default class ApiClient {
 	}
 
 	setState = ( state ) => {
-		if ( this.state !== state ) {
-			this.state = state;
-			this.subscriptionCallbacks.forEach( ( callback ) => callback( this ) );
-			updateDevInfo( this );
+		if ( this.state === state ) {
+			return;
 		}
+
+		this.state = state;
 		this.isClientStateInSync = true;
+		this.subscriptionCallbacks.forEach( ( callback ) => callback( this ) );
+		updateDevInfo( this );
 	}
 
 	subscribe = ( callback ) => {


### PR DESCRIPTION
The implementation of withSelect used in woocommerce-admin and
woocommerce-payments wasn't registering the updated state, which was
causing reqduests to not be scheduled when they needed to bo.

This fixes it by ensuring that 	isClientStateInSync is updated before
subscription callbacks are fired.

To Test:

Just run the example apps to ensure use, and then symlink the framework directory into woocommerce-admin node_modules to test there.
