### PR TITLE
Deprecate `requireResource`

### DIFF
--- a/packages/framework/src/client/index.js
+++ b/packages/framework/src/client/index.js
@@ -80,12 +80,14 @@ export default class ApiClient {
 	}
 
 	setState = ( state ) => {
-		if ( this.state !== state ) {
-			this.state = state;
-			this.subscriptionCallbacks.forEach( ( callback ) => callback( this ) );
-			updateDevInfo( this );
+		if ( this.state === state ) {
+			return;
 		}
+
+		this.state = state;
 		this.isClientStateInSync = true;
+		this.subscriptionCallbacks.forEach( ( callback ) => callback( this ) );
+		updateDevInfo( this );
 	}
 
 	subscribe = ( callback ) => {


### PR DESCRIPTION
This PR deprecates `requireResource` and adds its functionality into `getResource` instead using an optional `requirements` parameter. This further simplifies the selectors signatures.

To Test:
Run `npm run test` to ensure tests work.
Any use of `requireResource` should now give a console warning.

Still to do, update examples.